### PR TITLE
Update test so you cant upload a template without also doing its metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "chai-json-schema": "^1.5.0",
+    "jsonata": "^1.3.1",
     "mocha": "^3.4.2",
     "standard": "^10.0.3"
   },

--- a/test/template-files-test.js
+++ b/test/template-files-test.js
@@ -12,14 +12,39 @@
 const chai = require('chai')
 const fs = require('fs')
 const expect = chai.expect
+const jsonata = require('jsonata')
 
-const templateMetadata = require('../resources/template-metadata.json')
+const templateMetadataFilename = 'template-metadata.json'
+const templateMetadata = require('../resources/' + templateMetadataFilename)
 
 describe('Template files', function () {
-  it('must all exist', function () {
+  it('must all exist for the list in template-metadata', function () {
     for (let template of templateMetadata.templates) {
       let fileName = `./resources/${template.name}.yaml`
       expect(fs.existsSync(fileName), `Missing file ${fileName}`).equals(true)
     }
+  })
+  it('must all have an entry in template-metadata', function () {
+    let flowNames = jsonata('templates.name').evaluate(templateMetadata)
+    const listOfFiles = fs.readdirSync('./resources')
+
+    // Remove the templates-metadata.json file from the list we're checking against
+    const indexOfMetadata = listOfFiles.indexOf(templateMetadataFilename)
+    if (indexOfMetadata > -1) {
+      listOfFiles.splice(indexOfMetadata, 1)
+    }
+
+    // Iterate through each flow doc name and remove the file extension so can directly compare with the metadata file
+    // entries, list any missing ones and fail the test if any are missing
+    let missingFlowDocInMetadata = false
+    for (var i = 0; i < listOfFiles.length; i++) {
+      listOfFiles[i] = listOfFiles[i].substr(0, listOfFiles[i].lastIndexOf('.'))
+
+      if (flowNames.indexOf(listOfFiles[i]) === -1) {
+        console.log('This flow document is missing from the template-metadata file: ' + listOfFiles[i])
+        missingFlowDocInMetadata = true
+      }
+    }
+    expect(missingFlowDocInMetadata).equals(false)
   })
 })

--- a/test/template-metadata-schema-test.js
+++ b/test/template-metadata-schema-test.js
@@ -16,8 +16,8 @@ chai.use(require('chai-json-schema'))
 const templateMetadataSchema = require('./schema/template-metadata-schema.json')
 const templateMetadata = require('../resources/template-metadata.json')
 
-describe('Template Metadata Schema', function () {
-  it('is valid', function () {
+describe('Template Metadata', function () {
+  it('is valid against the given schema', function () {
     expect(templateMetadata).to.be.jsonSchema(templateMetadataSchema)
   })
 })


### PR DESCRIPTION
Update test so you cant upload a template without also doing its metadata
When going through the the procedure for this with Elaina, she was creating a spreadsheet to make sure she did metadata for any template she uploaded. This additional test will ensure it's done.

I changed the name on an existing flow to see to also see this fail.