### PR TITLE
Increase the max template name length from 38 to 98

### DIFF
--- a/test/schema/template-metadata-schema.json
+++ b/test/schema/template-metadata-schema.json
@@ -13,7 +13,7 @@
           "name": {
             "description": "The name of the template",
             "type": "string",
-            "maxLength": 38
+            "maxLength": 98
           },
           "description": {
             "description": "A description of the flow created with the template",


### PR DESCRIPTION
Increase the max template name length from 38 to 98.

Kept two characters below the actual max of 100, to allow for renaming of duplicate imports which adds a `_1`, `_2` etc to the end.