### PR TITLE
use-db2inst1-schema

### DIFF
--- a/resources/Populate a Salesforce campaign with leads captured in IBM Db2 and cognitively rate each lead.yaml
+++ b/resources/Populate a Salesforce campaign with leads captured in IBM Db2 and cognitively rate each lead.yaml
@@ -18,7 +18,7 @@ integration:
       triggers:
         RETRIEVEALL:
           input-context:
-            data: DB2ADMIN2_Leads
+            data: DB2INST1_Leads
           assembly:
             $ref: '#/integration/assemblies/assembly-2'
       connector-type: ibmdb2

--- a/resources/Populate a Salesforce campaign with leads captured in IBM Db2.yaml
+++ b/resources/Populate a Salesforce campaign with leads captured in IBM Db2.yaml
@@ -18,7 +18,7 @@ integration:
       triggers:
         RETRIEVEALL:
           input-context:
-            data: DB2ADMIN2_Leads
+            data: DB2INST1_Leads
           assembly:
             $ref: '#/integration/assemblies/assembly-2'
       connector-type: ibmdb2

--- a/resources/markdown/Populate a Salesforce campaign with leads captured in IBM Db2 and cognitively rate each lead_instructions.md
+++ b/resources/markdown/Populate a Salesforce campaign with leads captured in IBM Db2 and cognitively rate each lead_instructions.md
@@ -5,7 +5,7 @@ To refer to these instructions while editing the flow, open [the github page](ht
 This template references entities that you can create as follows:
 
 - In your Salesforce instance, create a custom field for the Campaign object to uniquely identify the event for which you are creating a campaign. Name the custom field **Conference** with a data type of **Text**.
-- In your IBM Db2 instance, create a database table named **LEADS**.  Sample DDL:
+- In your IBM Db2 instance, create a database table named **LEADS** in the **DB2INST1** schema.  Sample DDL:
   `CREATE TABLE LEADS (LEADID SMALLINT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1), FIRSTNAME VARCHAR(25), LASTNAME VARCHAR(25), FULLNAME VARCHAR(60), ADDRESS1 VARCHAR(255), ADDRESS2 VARCHAR(255), ADDRESS3 VARCHAR(255), ADDRESS4 VARCHAR(255), CITY VARCHAR(25), REGION VARCHAR(25), POSTALCD VARCHAR(25), COUNTRY VARCHAR(25), PHONE VARCHAR(25), COMPANY VARCHAR(255), LEADTXT VARCHAR(255), CONFERENCE VARCHAR(255), EMAIL VARCHAR(60))`
 
   Insert some sample data into the LEADS table.

--- a/resources/markdown/Populate a Salesforce campaign with leads captured in IBM Db2_instructions.md
+++ b/resources/markdown/Populate a Salesforce campaign with leads captured in IBM Db2_instructions.md
@@ -1,11 +1,11 @@
-To refer to these instructions while editing the flow, open [the github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Populate%20a%20Salesforce%20campaign%20with%20leads%20captured%20in%20IBM%20Db2_instructions.md) (opens in a new window). 
+To refer to these instructions while editing the flow, open [the github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Populate%20a%20Salesforce%20campaign%20with%20leads%20captured%20in%20IBM%20Db2_instructions.md) (opens in a new window).
 
 ## Prerequisites
 
 This template references entities that you can create as follows:
 
 - In your Salesforce instance, create a custom field for the Campaign object to uniquely identify the event for which you are creating a campaign. Name the custom field **Conference** with a data type of **Text**.
-- In your IBM Db2 instance, create a database table named **LEADS**.  Sample DDL:
+- In your IBM Db2 instance, create a database table named **LEADS** in the **DB2INST1** schema.  Sample DDL:
   `CREATE TABLE LEADS (LEADID SMALLINT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1), FIRSTNAME VARCHAR(25), LASTNAME VARCHAR(25), FULLNAME VARCHAR(60), ADDRESS1 VARCHAR(255), ADDRESS2 VARCHAR(255), ADDRESS3 VARCHAR(255), ADDRESS4 VARCHAR(255), CITY VARCHAR(25), REGION VARCHAR(25), POSTALCD VARCHAR(25), COUNTRY VARCHAR(25), PHONE VARCHAR(25), COMPANY VARCHAR(255), LEADTXT VARCHAR(255), CONFERENCE VARCHAR(255), EMAIL VARCHAR(60))`
 
   Insert some sample data into the LEADS table.


### PR DESCRIPTION
Most people would not create tables in the DB2ADMIN schema but would typically use the DB2INST1 schema if using the  DB2 sample config.