### PR TITLE
Fix JSONata expressions in templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "6.11"
+  - "8"
+  - "10"
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "chai": "^4.0.2",
     "chai-json-schema": "^1.5.0",
     "jsonata": "^1.3.1",
-    "mocha": "^3.4.2",
-    "standard": "^10.0.3"
+    "mocha": "^5.2.0",
+    "standard": "^12.0.1"
   },
   "standard": {
     "globals": [],

--- a/resources/Create a Pardot prospect when a row is appended in Google Sheets.yaml
+++ b/resources/Create a Pardot prospect when a row is appended in Google Sheets.yaml
@@ -37,11 +37,11 @@ integration:
               map:
                 mappings:
                   - email:
-                      template: '{{$Trigger.fields.3}}'
+                      template: '{{$Trigger.fields."3"}}'
                   - first_name:
-                      template: '{{$Trigger.fields.1}}'
+                      template: '{{$Trigger.fields."1"}}'
                   - last_name:
-                      template: '{{$Trigger.fields.2}}'
+                      template: '{{$Trigger.fields."2"}}'
                 $map: 'http://ibm.com/appconnect/map/v1'
                 input:
                   - variable: Trigger

--- a/resources/Send me a Twilio SMS when a new row is added in Google Sheets.yaml
+++ b/resources/Send me a Twilio SMS when a new row is added in Google Sheets.yaml
@@ -38,8 +38,8 @@ integration:
                 mappings:
                   - Body:
                       template: >-
-                        New event {{$Trigger.fields.1}} planned in
-                        {{$Trigger.fields.2}}
+                        New event {{$Trigger.fields."1"}} planned in
+                        {{$Trigger.fields."2"}}
                 $map: 'http://ibm.com/appconnect/map/v1'
                 input:
                   - variable: Trigger


### PR DESCRIPTION
The JSONata expressions used in the templates are not valid for JSONata 1.5.2 and above. Expressions with the invalid format cannot be created in App Connect via the UI any more (or indeed for a long time), so the templates should be updated so they remain valid.

Also brought Travis up to using the latest nodeJS LTS versions, and updated the dependencies to the latest major versions.