### PR TITLE
Migrate batch templates to use BatchprocessOutput for the output

### DIFF
--- a/resources/Sync Salesforce Leads between accounts and check and record state.yaml
+++ b/resources/Sync Salesforce Leads between accounts and check and record state.yaml
@@ -140,35 +140,35 @@ integration:
                 mappings:
                   - Body:
                       template: >-
-                        Batch status: {{$Batchprocess.status}}.
+                        Batch status: {{$BatchprocessOutput.status}}.
 
                         Number of records processed:
-                        {{$Batchprocess.recordsProcessed.total}} of which
-                        {{$Batchprocess.recordsProcessed.success}} were
-                        successful, {{$Batchprocess.recordsProcessed.error}}
-                        failed and {{$Batchprocess.recordsProcessed.canceled}}
+                        {{$BatchprocessOutput.recordsProcessed.total}} of which
+                        {{$BatchprocessOutput.recordsProcessed.success}} were
+                        successful, {{$BatchprocessOutput.recordsProcessed.error}}
+                        failed and {{$BatchprocessOutput.recordsProcessed.canceled}}
                         were canceled.
 
-                        Batch End Time: {{$Batchprocess.end}} 
+                        Batch End Time: {{$BatchprocessOutput.end}}
 
                         Batch id for problem determination :
-                        {{$Batchprocess.batchInstanceId}}
+                        {{$BatchprocessOutput.batchInstanceId}}
                   - Subject:
-                      template: 'Results of batch started at {{$Batchprocess.start}}'
+                      template: 'Results of batch started at {{$BatchprocessOutput.start}}'
                   - To:
                       template: my@email.com
                 $map: 'http://ibm.com/appconnect/map/v1'
                 input:
                   - variable: Trigger
                     $ref: '#/trigger/payload'
-                  - variable: Batchprocess
+                  - variable: BatchprocessOutput
                     $ref: '#/node-output/Batch process/response/payload'
           - if:
               name: If
               input:
                 - variable: Trigger
                   $ref: '#/trigger/payload'
-                - variable: Batchprocess
+                - variable: BatchprocessOutput
                   $ref: '#/node-output/Batch process/response/payload'
                 - variable: GoogleSheetsCreaterow2
                   $ref: '#/node-output/Google Sheets Create row 2/response/payload'
@@ -186,21 +186,21 @@ integration:
                                 template: C2V1VE04T
                             - text:
                                 template: >-
-                                  Batch {{$Batchprocess.batchInstanceId}}timed
-                                  out at {{$Batchprocess.end}}. so far
-                                  {{$Batchprocess.recordsProcessed}}
+                                  Batch {{$BatchprocessOutput.batchInstanceId}}timed
+                                  out at {{$BatchprocessOutput.end}}. so far
+                                  {{$BatchprocessOutput.recordsProcessed}}
                           $map: 'http://ibm.com/appconnect/map/v1'
                           input:
                             - variable: Trigger
                               $ref: '#/trigger/payload'
-                            - variable: Batchprocess
+                            - variable: BatchprocessOutput
                               $ref: '#/node-output/Batch process/response/payload'
                             - variable: GoogleSheetsCreaterow2
                               $ref: >-
                                 #/node-output/Google Sheets Create row
                                 2/response/payload
                 - condition:
-                    '{{$Batchprocess.status}}': Retrieve Failed
+                    '{{$BatchprocessOutput.status}}': Retrieve Failed
                   execute:
                     - create-action:
                         name: Slack Create message 2
@@ -213,12 +213,12 @@ integration:
                             - text:
                                 template: >-
                                   Batch retrieve failed
-                                  {{$Batchprocess.batchInstanceId}}
+                                  {{$BatchprocessOutput.batchInstanceId}}
                           $map: 'http://ibm.com/appconnect/map/v1'
                           input:
                             - variable: Trigger
                               $ref: '#/trigger/payload'
-                            - variable: Batchprocess
+                            - variable: BatchprocessOutput
                               $ref: '#/node-output/Batch process/response/payload'
                             - variable: GoogleSheetsCreaterow2
                               $ref: >-
@@ -230,14 +230,14 @@ integration:
                         input:
                           - variable: Trigger
                             $ref: '#/trigger/payload'
-                          - variable: Batchprocess
+                          - variable: BatchprocessOutput
                             $ref: '#/node-output/Batch process/response/payload'
                           - variable: GoogleSheetsCreaterow2
                             $ref: >-
                               #/node-output/Google Sheets Create row
                               2/response/payload
                         message: >-
-                          Batch {{$Batchprocess.batchInstanceId}} failed on
+                          Batch {{$BatchprocessOutput.batchInstanceId}} failed on
                           retrieve
                         status-code: 400
               else:

--- a/resources/Sync leads between Salesforce accounts and send email with the sync result.yaml
+++ b/resources/Sync leads between Salesforce accounts and send email with the sync result.yaml
@@ -142,11 +142,11 @@ integration:
               input:
                 - variable: Trigger
                   $ref: '#/trigger/payload'
-                - variable: Batchprocess
+                - variable: BatchprocessOutput
                   $ref: '#/node-output/Batch process/response/payload'
               branch:
                 - condition:
-                    '{{$Batchprocess.status}}': Complete
+                    '{{$BatchprocessOutput.status}}': Complete
                   execute:
                     - create-action:
                         name: Gmail Create email
@@ -157,8 +157,8 @@ integration:
                             - Body:
                                 template: >-
                                   Batch retreive process
-                                  {{$Batchprocess.batchInstanceId}} retrieved
-                                  {{$Batchprocess.recordsProcessed.success}}
+                                  {{$BatchprocessOutput.batchInstanceId}} retrieved
+                                  {{$BatchprocessOutput.recordsProcessed.success}}
                                   records successfully
                             - Subject:
                                 template: Leads created
@@ -168,10 +168,10 @@ integration:
                           input:
                             - variable: Trigger
                               $ref: '#/trigger/payload'
-                            - variable: Batchprocess
+                            - variable: BatchprocessOutput
                               $ref: '#/node-output/Batch process/response/payload'
                 - condition:
-                    '{{$Batchprocess.status}}': Retrieve failed
+                    '{{$BatchprocessOutput.status}}': Retrieve failed
                   execute:
                     - create-action:
                         name: Gmail Create email 2
@@ -182,9 +182,9 @@ integration:
                             - Body:
                                 template: >-
                                   Batch retrieve process
-                                  {{$Batchprocess.batchInstanceId}} failed to
+                                  {{$BatchprocessOutput.batchInstanceId}} failed to
                                   retrieve
-                                  {{$Batchprocess.recordsProcessed.error}}
+                                  {{$BatchprocessOutput.recordsProcessed.error}}
                                   records
                             - Subject:
                                 template: Retrieval of leads failed
@@ -194,10 +194,10 @@ integration:
                           input:
                             - variable: Trigger
                               $ref: '#/trigger/payload'
-                            - variable: Batchprocess
+                            - variable: BatchprocessOutput
                               $ref: '#/node-output/Batch process/response/payload'
                 - condition:
-                    '{{$Batchprocess.status}}': Stopped
+                    '{{$BatchprocessOutput.status}}': Stopped
                   execute:
                     - create-action:
                         name: Gmail Create email 3
@@ -208,7 +208,7 @@ integration:
                             - Body:
                                 template: >-
                                   Batch retrieve process
-                                  {{$Batchprocess.batchInstanceId}} was stopped
+                                  {{$BatchprocessOutput.batchInstanceId}} was stopped
                             - Subject:
                                 template: Retrieval of leads stopped
                             - To:
@@ -217,10 +217,10 @@ integration:
                           input:
                             - variable: Trigger
                               $ref: '#/trigger/payload'
-                            - variable: Batchprocess
+                            - variable: BatchprocessOutput
                               $ref: '#/node-output/Batch process/response/payload'
                 - condition:
-                    '{{$Batchprocess.status}}': Timed out
+                    '{{$BatchprocessOutput.status}}': Timed out
                   execute:
                     - create-action:
                         name: Slack Create message
@@ -233,12 +233,12 @@ integration:
                             - text:
                                 template: >-
                                   Batch retrieve process
-                                  {{$Batchprocess.batchInstanceId}} timed out
+                                  {{$BatchprocessOutput.batchInstanceId}} timed out
                           $map: 'http://ibm.com/appconnect/map/v1'
                           input:
                             - variable: Trigger
                               $ref: '#/trigger/payload'
-                            - variable: Batchprocess
+                            - variable: BatchprocessOutput
                               $ref: '#/node-output/Batch process/response/payload'
               else:
                 execute: []
@@ -248,7 +248,7 @@ integration:
                       input:
                         - variable: Trigger
                           $ref: '#/trigger/payload'
-                        - variable: Batchprocess
+                        - variable: BatchprocessOutput
                           $ref: '#/node-output/Batch process/response/payload'
                       message: Should not happen
                       status-code: 400


### PR DESCRIPTION
Migrating any templates that use Batch process to use a unique variable (`BatchprocessOutput`) for the batch output that doesn't clash with the batch current item (`Batchprocess`)