### PR TITLE
IBM OpenPages - shahmini

### DIFF
--- a/resources/Add a document in IBM Watson Discovery when a file is created in IBM OpenPages with Watson.yaml
+++ b/resources/Add a document in IBM Watson Discovery when a file is created in IBM OpenPages with Watson.yaml
@@ -118,7 +118,7 @@ integration:
                       document/response/payload
                   - variable: flowDetails
                     $ref: '#/flowDetails'
-  name: Add a document in IBM Watson Discovery when a file is created in IBM OpenPages with Watson
+  name: Add a document in IBM Watson Discovery when a file gets created in IBM OpenPages with Watson
   description: >-
     Use this template to add a document in IBM Watson Discovery whenever a file is created and downloaded in IBM OpenPages with Watson.
 models: {}

--- a/resources/Add a document in IBM Watson Discovery when a file is created in IBM OpenPages with Watson.yaml
+++ b/resources/Add a document in IBM Watson Discovery when a file is created in IBM OpenPages with Watson.yaml
@@ -1,0 +1,124 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: ibmopenpages
+      type: event-trigger
+      triggers:
+        CREATED_POLLER:
+          input-context:
+            data: file
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              createdField: Creation_Date
+              updatedField: Last_Modification_Date
+              timeFormat: YYYY-MM-DDTHH:mm:ss.SSSZ
+              timeZone: UTC
+              pollingInterval: 1
+              isCreatedQueryable: true
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: file
+      connector-type: ibmopenpages
+      actions:
+        DOWNLOADFILE: {}
+    action-interface-3:
+      type: api-action
+      business-object: message
+      connector-type: slack
+      actions:
+        CREATE: {}
+    action-interface-2:
+      type: api-action
+      business-object: document
+      connector-type: watsondiscovery
+      actions:
+        CREATE: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - custom-action:
+              name: IBM OpenPages with Watson Download file
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              action: DOWNLOADFILE
+              map:
+                mappings:
+                  - Resource_ID:
+                      expression: '$Trigger.Resource_ID '
+                  - fileName:
+                      template: '{{$Trigger.Name}}'
+                  - fileType:
+                      template: Binary
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+          - create-action:
+              name: IBM Watson Discovery Add document
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              map:
+                mappings:
+                  - _source:
+                      template: OP
+                  - _sourceid:
+                      template: '{{$Trigger.Resource_ID}}'
+                  - collection_id:
+                      template: 1a3f5f4c-8ce5-4d47-0000-017fa77650fe
+                  - content_type:
+                      template: Binary
+                  - file:
+                      template: '{{$IBMOpenPageswithWatsonDownloadfile.fileContent}}'
+                  - file_name:
+                      template: '{{$Trigger.Name}}'
+                  - project_id:
+                      template: cd93d1c7-fc68-463b-9118-2d2f3f718862
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: IBMOpenPageswithWatsonDownloadfile
+                    $ref: >-
+                      #/node-output/IBM OpenPages with Watson Download
+                      file/response/payload
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+          - create-action:
+              name: Slack Send message
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              map:
+                mappings:
+                  - channel:
+                      template: C03KG72B91D
+                  - text:
+                      template: >-
+                        Fileusecase : Document created
+                        {{$IBMWatsonDiscoveryAdddocument.document_id}}for file
+                        {{$Trigger.Resource_ID}}
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: IBMOpenPageswithWatsonDownloadfile
+                    $ref: >-
+                      #/node-output/IBM OpenPages with Watson Download
+                      file/response/payload
+                  - variable: IBMWatsonDiscoveryAdddocument
+                    $ref: >-
+                      #/node-output/IBM Watson Discovery Add
+                      document/response/payload
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Add a document in IBM Watson Discovery when a file is created in IBM OpenPages with Watson
+  description: >-
+    Use this template to add a document in IBM Watson Discovery whenever a file is created and downloaded in IBM OpenPages with Watson.
+models: {}

--- a/resources/Create an issue in IBM OpenPages with Watson when an incident is created in ServiceNow.yaml
+++ b/resources/Create an issue in IBM OpenPages with Watson when an incident is created in ServiceNow.yaml
@@ -374,8 +374,8 @@ integration:
                           - variable: flowDetails
                             $ref: '#/flowDetails'
               output-schema: {}
-  name: Create an issue in IBM OpenPages with Watson when an incident is created in ServiceNow
+  name: Create an issue in IBM OpenPages with Watson when an incident gets created in ServiceNow
   description: >-
-    Use this template to create an issue in IBM OpenPages with Watson whenever an incident is created in ServiceNow. 
+    Use this template to create an issue in IBM OpenPages with Watson whenever an incident gets created in ServiceNow. 
     This flow helps you to keep incident data in sync between ServiceNow and IBM OpenPages with Watson.
 models: {}

--- a/resources/Create an issue in IBM OpenPages with Watson when an incident is created in ServiceNow.yaml
+++ b/resources/Create an issue in IBM OpenPages with Watson when an incident is created in ServiceNow.yaml
@@ -1,0 +1,381 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        CREATED:
+          input-context:
+            data: incident
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options: {}
+      connector-type: servicenow
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: user
+      connector-type: ibmopenpages
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: message
+      connector-type: slack
+      actions:
+        CREATE: {}
+    action-interface-3:
+      type: api-action
+      business-object: sys_user
+      connector-type: servicenow
+      actions:
+        RETRIEVEALL: {}
+    action-interface-4:
+      type: api-action
+      business-object: message
+      connector-type: slack
+      actions:
+        CREATE: {}
+    action-interface-5:
+      type: api-action
+      business-object: user
+      connector-type: ibmopenpages
+      actions:
+        CREATE: {}
+    action-interface-6:
+      type: api-action
+      business-object: issue
+      connector-type: ibmopenpages
+      actions:
+        CREATE: {}
+    action-interface-9:
+      type: api-action
+      business-object: message
+      connector-type: slack
+      actions:
+        CREATE: {}
+    action-interface-7:
+      type: api-action
+      business-object: message
+      connector-type: slack
+      actions:
+        CREATE: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - if:
+              name: If 2
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Trigger.priority}}':
+                      gt: '4'
+                  execute:
+                    - retrieve-action:
+                        name: ServiceNow Retrieve system users
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-3'
+                        filter:
+                          where:
+                            sys_id: '{{$Trigger.assigned_to.value}}'
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 1
+                        allow-truncation: true
+                        pagination-type: TOKEN
+                        allow-empty-output: true
+                    - retrieve-action:
+                        name: IBM OpenPages with Watson Retrieve users
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-1'
+                        filter:
+                          limit: 10
+                        allow-truncation: true
+                        allow-empty-output: true
+                    - if:
+                        name: If
+                        input:
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: ServiceNowRetrieveincidents
+                            $ref: >-
+                              #/node-output/ServiceNow Retrieve
+                              incidents/response/payload
+                          - variable: ServiceNowRetrieveincidentsMetadata
+                            $ref: >-
+                              #/node-output/ServiceNow Retrieve
+                              incidents/response
+                          - variable: SlackSendmessage3
+                            $ref: >-
+                              #/node-output/Slack Send message
+                              3/response/payload
+                          - variable: ServiceNowRetrievesystemusers
+                            $ref: >-
+                              #/node-output/ServiceNow Retrieve system
+                              users/response/payload
+                          - variable: ServiceNowRetrievesystemusersMetadata
+                            $ref: >-
+                              #/node-output/ServiceNow Retrieve system
+                              users/response
+                          - variable: IBMOpenPageswithWatsonRetrieveusers
+                            $ref: >-
+                              #/node-output/IBM OpenPages with Watson Retrieve
+                              users/response/payload
+                          - variable: IBMOpenPageswithWatsonRetrieveusersMetadata
+                            $ref: >-
+                              #/node-output/IBM OpenPages with Watson Retrieve
+                              users/response
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        branch:
+                          - condition:
+                              '{{$ServiceNowRetrievesystemusers.user_name in $IBMOpenPageswithWatsonRetrieveusers.userName }}':
+                                '=': 'true'
+                            execute:
+                              - create-action:
+                                  name: Slack Send message
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-2
+                                  map:
+                                    mappings:
+                                      - channel:
+                                          template: C03KG72B91D
+                                      - text:
+                                          template: >-
+                                            Users from OP -
+                                            {{$IBMOpenPageswithWatsonRetrieveusers.userName}}
+                                            contains
+                                            {{$ServiceNowRetrievesystemusers.user_name}}
+                                            - Not creating userin OP
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: ServiceNowRetrievesystemusers
+                                        $ref: >-
+                                          #/block/If 2/node-output/ServiceNow
+                                          Retrieve system users/response/payload
+                                      - variable: ServiceNowRetrievesystemusersMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/ServiceNow
+                                          Retrieve system users/response
+                                      - variable: IBMOpenPageswithWatsonRetrieveusers
+                                        $ref: >-
+                                          #/block/If 2/node-output/IBM OpenPages
+                                          with Watson Retrieve
+                                          users/response/payload
+                                      - variable: >-
+                                          IBMOpenPageswithWatsonRetrieveusersMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/IBM OpenPages
+                                          with Watson Retrieve users/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                        else:
+                          execute:
+                            - create-action:
+                                name: IBM OpenPages with Watson Create user
+                                target:
+                                  $ref: >-
+                                    #/integration/action-interfaces/action-interface-5
+                                map:
+                                  mappings:
+                                    - emailAddress:
+                                        template: '{{$ServiceNowRetrievesystemusers.email}}'
+                                    - firstName:
+                                        template: >-
+                                          {{$ServiceNowRetrievesystemusers.first_name}}
+                                    - lastName:
+                                        template: >-
+                                          {{$ServiceNowRetrievesystemusers.last_name}}
+                                    - localeISOCode:
+                                        template: French
+                                    - password:
+                                        template: '{{$random()}}'
+                                    - userName:
+                                        template: >-
+                                          {{$ServiceNowRetrievesystemusers.user_name}}
+                                  $map: http://ibm.com/appconnect/map/v1
+                                  input:
+                                    - variable: Trigger
+                                      $ref: '#/trigger/payload'
+                                    - variable: ServiceNowRetrievesystemusers
+                                      $ref: >-
+                                        #/block/If 2/node-output/ServiceNow
+                                        Retrieve system users/response/payload
+                                    - variable: ServiceNowRetrievesystemusersMetadata
+                                      $ref: >-
+                                        #/block/If 2/node-output/ServiceNow
+                                        Retrieve system users/response
+                                    - variable: IBMOpenPageswithWatsonRetrieveusers
+                                      $ref: >-
+                                        #/block/If 2/node-output/IBM OpenPages
+                                        with Watson Retrieve
+                                        users/response/payload
+                                    - variable: >-
+                                        IBMOpenPageswithWatsonRetrieveusersMetadata
+                                      $ref: >-
+                                        #/block/If 2/node-output/IBM OpenPages
+                                        with Watson Retrieve users/response
+                                    - variable: flowDetails
+                                      $ref: '#/flowDetails'
+                            - create-action:
+                                name: Slack Send message 2
+                                target:
+                                  $ref: >-
+                                    #/integration/action-interfaces/action-interface-4
+                                map:
+                                  mappings:
+                                    - channel:
+                                        template: C03KG72B91D
+                                    - text:
+                                        template: >-
+                                          OP else
+                                          {{$IBMOpenPageswithWatsonRetrieveusers.userName}}
+                                          doesn't contain
+                                          {{$ServiceNowRetrievesystemusers.user_name}}
+                                          created user in op with usernamein op
+                                          {{$IBMOpenPageswithWatsonCreateuser.id}}
+                                  $map: http://ibm.com/appconnect/map/v1
+                                  input:
+                                    - variable: Trigger
+                                      $ref: '#/trigger/payload'
+                                    - variable: IBMOpenPageswithWatsonCreateuser
+                                      $ref: >-
+                                        #/block/If/node-output/IBM OpenPages
+                                        with Watson Create user/response/payload
+                                    - variable: ServiceNowRetrievesystemusers
+                                      $ref: >-
+                                        #/block/If 2/node-output/ServiceNow
+                                        Retrieve system users/response/payload
+                                    - variable: ServiceNowRetrievesystemusersMetadata
+                                      $ref: >-
+                                        #/block/If 2/node-output/ServiceNow
+                                        Retrieve system users/response
+                                    - variable: IBMOpenPageswithWatsonRetrieveusers
+                                      $ref: >-
+                                        #/block/If 2/node-output/IBM OpenPages
+                                        with Watson Retrieve
+                                        users/response/payload
+                                    - variable: >-
+                                        IBMOpenPageswithWatsonRetrieveusersMetadata
+                                      $ref: >-
+                                        #/block/If 2/node-output/IBM OpenPages
+                                        with Watson Retrieve users/response
+                                    - variable: flowDetails
+                                      $ref: '#/flowDetails'
+                        output-schema: {}
+                    - create-action:
+                        name: IBM OpenPages with Watson Create issue
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-6'
+                        map:
+                          mappings:
+                            - OPLC_Std_LCAssignee:
+                                template: '{{$ServiceNowRetrievesystemusers.user_name}}'
+                            - OPSS_Iss_Due_Date:
+                                template: '{{$Trigger.due_date}}'
+                            - PARENT_TYPE:
+                                template: Business Entity
+                            - description:
+                                template: '{{$Trigger.short_description}}'
+                            - name:
+                                template: '{{$Trigger.number}}'
+                            - primaryParentId:
+                                template: '1735'
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ServiceNowRetrievesystemusers
+                              $ref: >-
+                                #/block/If 2/node-output/ServiceNow Retrieve
+                                system users/response/payload
+                            - variable: ServiceNowRetrievesystemusersMetadata
+                              $ref: >-
+                                #/block/If 2/node-output/ServiceNow Retrieve
+                                system users/response
+                            - variable: IBMOpenPageswithWatsonRetrieveusers
+                              $ref: >-
+                                #/block/If 2/node-output/IBM OpenPages with
+                                Watson Retrieve users/response/payload
+                            - variable: IBMOpenPageswithWatsonRetrieveusersMetadata
+                              $ref: >-
+                                #/block/If 2/node-output/IBM OpenPages with
+                                Watson Retrieve users/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                    - create-action:
+                        name: Slack Send message 4
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-9'
+                        map:
+                          mappings:
+                            - channel:
+                                template: C03KG72B91D
+                            - text:
+                                template: >-
+                                  Issue created in OP
+                                  {{$IBMOpenPageswithWatsonCreateissue.Resource_ID}}
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ServiceNowRetrievesystemusers
+                              $ref: >-
+                                #/block/If 2/node-output/ServiceNow Retrieve
+                                system users/response/payload
+                            - variable: ServiceNowRetrievesystemusersMetadata
+                              $ref: >-
+                                #/block/If 2/node-output/ServiceNow Retrieve
+                                system users/response
+                            - variable: IBMOpenPageswithWatsonRetrieveusers
+                              $ref: >-
+                                #/block/If 2/node-output/IBM OpenPages with
+                                Watson Retrieve users/response/payload
+                            - variable: IBMOpenPageswithWatsonRetrieveusersMetadata
+                              $ref: >-
+                                #/block/If 2/node-output/IBM OpenPages with
+                                Watson Retrieve users/response
+                            - variable: IBMOpenPageswithWatsonCreateissue
+                              $ref: >-
+                                #/block/If 2/node-output/IBM OpenPages with
+                                Watson Create issue/response/payload
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+              else:
+                execute:
+                  - create-action:
+                      name: Slack Send message 3
+                      target:
+                        $ref: '#/integration/action-interfaces/action-interface-7'
+                      map:
+                        mappings:
+                          - channel:
+                              template: C03KG72B91D
+                          - text:
+                              template: >-
+                                No need to create issue in OP for
+                                {{$Trigger.number}}
+                        $map: http://ibm.com/appconnect/map/v1
+                        input:
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+              output-schema: {}
+  name: Create an issue in IBM OpenPages with Watson when an incident is created in ServiceNow
+  description: >-
+    Use this template to create an issue in IBM OpenPages with Watson whenever an incident is created in ServiceNow. 
+    This flow helps you to keep incident data in sync between ServiceNow and IBM OpenPages with Watson.
+models: {}


### PR DESCRIPTION
UC1 - Create an issue in IBM OpenPages with Watson when an incident is created in ServiceNow
UC2 - Add a document in IBM Watson Discovery when a file is created in IBM OpenPages with Watson

Applicable to cp4i