### PR TITLE
issues with templates (epic_3358)

### DIFF
--- a/resources/Create a row in a Google Sheets spreadsheet when an issue is created or updated on GitHub.yaml
+++ b/resources/Create a row in a Google Sheets spreadsheet when an issue is created or updated on GitHub.yaml
@@ -22,6 +22,7 @@ integration:
               timeFormat: YYYY-MM-DDTHH:mm:ss.SSSZ
               timeZone: UTC
               pollingInterval: 1
+      connector-type: github
   action-interfaces:
     action-interface-1:
       type: api-action


### PR DESCRIPTION
Issue with templates (epic_3358).

Fixing issues - Create a row in a Google Sheets spreadsheet when an issue is created or updated on GitHub.yaml (batch2)