### PR TITLE
Usecase for Toggl Track

### DIFF
--- a/resources/Create the invoice in Quickbooks based on billable hours tracked in Toggl Track.yaml
+++ b/resources/Create the invoice in Quickbooks based on billable hours tracked in Toggl Track.yaml
@@ -1,0 +1,644 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: false
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: getMeTimeEntries_model
+      connector-type: toggltrack
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: getWorkspacesByWorkspaceIdProjects_model
+      connector-type: toggltrack
+      actions:
+        RETRIEVEALL: {}
+    action-interface-3:
+      type: api-action
+      business-object: customer
+      connector-type: quickbooks
+      actions:
+        RETRIEVEALL: {}
+    action-interface-4:
+      type: api-action
+      business-object: getWorkspacesByWorkspaceIdClients_model
+      connector-type: toggltrack
+      actions:
+        RETRIEVEALL: {}
+    action-interface-5:
+      type: api-action
+      business-object: customer
+      connector-type: quickbooks
+      actions:
+        CREATE: {}
+    action-interface-6:
+      type: api-action
+      business-object: invoice
+      connector-type: quickbooks
+      actions:
+        CREATE: {}
+    action-interface-7:
+      type: api-action
+      business-object: invoice
+      connector-type: quickbooks
+      actions:
+        CREATE: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Toggl Track Retrieve time entries
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  since:
+                    gt: ''
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$TogglTrackRetrievetimeentries '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: TogglTrackRetrievetimeentries
+                    $ref: >-
+                      #/node-output/Toggl Track Retrieve time
+                      entries/response/payload
+                  - variable: TogglTrackRetrievetimeentriesMetadata
+                    $ref: '#/node-output/Toggl Track Retrieve time entries/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Toggl Track Time entries
+        tags:
+          - incomplete
+    assembly-2:
+      assembly:
+        execute:
+          - if:
+              name: If
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: TogglTrackRetrievetimeentries
+                  $ref: >-
+                    #/node-output/Toggl Track Retrieve time
+                    entries/response/payload
+                - variable: TogglTrackRetrievetimeentriesMetadata
+                  $ref: '#/node-output/Toggl Track Retrieve time entries/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem.billable}}': 'true'
+                  execute:
+                    - retrieve-action:
+                        name: Toggl Track Retrieve workspace projects
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-2'
+                        filter:
+                          where:
+                            workspace_id: '{{$Foreachitem.workspace_id}}'
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: TogglTrackRetrievetimeentries
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response/payload
+                            - variable: TogglTrackRetrievetimeentriesMetadata
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 10
+                        allow-truncation: true
+                        pagination-type: SKIP_LIMIT
+                        allow-empty-output: false
+                    - for-each:
+                        name: For each 2
+                        assembly:
+                          $ref: '#/integration/assemblies/assembly-3'
+                        source:
+                          expression: '$TogglTrackRetrieveworkspaceprojects '
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: TogglTrackRetrieveworkspaceprojects
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response/payload
+                            - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response
+                            - variable: TogglTrackRetrievetimeentries
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response/payload
+                            - variable: TogglTrackRetrievetimeentriesMetadata
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                        mode: sequential
+                        continue-on-error: true
+                        map:
+                          $map: http://ibm.com/appconnect/map/v1
+                          mappings: []
+                        display-name: Toggl Track Workspace projects
+              else:
+                execute: []
+              output-schema: {}
+    assembly-3:
+      assembly:
+        execute:
+          - if:
+              name: If 2
+              input:
+                - variable: Foreach2item
+                  $ref: '#/block/For each 2/current-item'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: TogglTrackRetrieveworkspaceprojects
+                  $ref: >-
+                    #/block/If/node-output/Toggl Track Retrieve workspace
+                    projects/response/payload
+                - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                  $ref: >-
+                    #/block/If/node-output/Toggl Track Retrieve workspace
+                    projects/response
+                - variable: TogglTrackRetrievetimeentries
+                  $ref: >-
+                    #/node-output/Toggl Track Retrieve time
+                    entries/response/payload
+                - variable: TogglTrackRetrievetimeentriesMetadata
+                  $ref: '#/node-output/Toggl Track Retrieve time entries/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem.project_id}}': '{{$Foreach2item.id}}'
+                  execute:
+                    - retrieve-action:
+                        name: Toggl Track Retrieve clients
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-4'
+                        filter:
+                          where:
+                            workspace_id: '{{$Foreachitem.workspace_id}}'
+                          input:
+                            - variable: Foreach2item
+                              $ref: '#/block/For each 2/current-item'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: TogglTrackRetrieveworkspaceprojects
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response/payload
+                            - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response
+                            - variable: TogglTrackRetrievetimeentries
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response/payload
+                            - variable: TogglTrackRetrievetimeentriesMetadata
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 10
+                        allow-truncation: false
+                        allow-empty-output: false
+                    - for-each:
+                        name: For each 3
+                        assembly:
+                          $ref: '#/integration/assemblies/assembly-4'
+                        source:
+                          expression: '$TogglTrackRetrieveclients '
+                          input:
+                            - variable: Foreach2item
+                              $ref: '#/block/For each 2/current-item'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: TogglTrackRetrieveclients
+                              $ref: >-
+                                #/block/If 2/node-output/Toggl Track Retrieve
+                                clients/response/payload
+                            - variable: TogglTrackRetrieveclientsMetadata
+                              $ref: >-
+                                #/block/If 2/node-output/Toggl Track Retrieve
+                                clients/response
+                            - variable: TogglTrackRetrieveworkspaceprojects
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response/payload
+                            - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response
+                            - variable: TogglTrackRetrievetimeentries
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response/payload
+                            - variable: TogglTrackRetrievetimeentriesMetadata
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                        mode: sequential
+                        continue-on-error: true
+                        map:
+                          $map: http://ibm.com/appconnect/map/v1
+                          mappings: []
+                        display-name: Toggl Track Clients
+              else:
+                execute: []
+              output-schema: {}
+    assembly-4:
+      assembly:
+        execute:
+          - if:
+              name: If 3
+              input:
+                - variable: Foreach3item
+                  $ref: '#/block/For each 3/current-item'
+                - variable: Foreach2item
+                  $ref: '#/block/For each 2/current-item'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: TogglTrackRetrieveclients
+                  $ref: >-
+                    #/block/If 2/node-output/Toggl Track Retrieve
+                    clients/response/payload
+                - variable: TogglTrackRetrieveclientsMetadata
+                  $ref: >-
+                    #/block/If 2/node-output/Toggl Track Retrieve
+                    clients/response
+                - variable: TogglTrackRetrieveworkspaceprojects
+                  $ref: >-
+                    #/block/If/node-output/Toggl Track Retrieve workspace
+                    projects/response/payload
+                - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                  $ref: >-
+                    #/block/If/node-output/Toggl Track Retrieve workspace
+                    projects/response
+                - variable: TogglTrackRetrievetimeentries
+                  $ref: >-
+                    #/node-output/Toggl Track Retrieve time
+                    entries/response/payload
+                - variable: TogglTrackRetrievetimeentriesMetadata
+                  $ref: '#/node-output/Toggl Track Retrieve time entries/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreach2item.client_id}}': '{{$Foreach3item.id}}'
+                  execute:
+                    - retrieve-action:
+                        name: QuickBooks Retrieve customers
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-3'
+                        filter:
+                          where:
+                            CompanyName: '{{$Foreach3item.name}}'
+                          input:
+                            - variable: Foreach3item
+                              $ref: '#/block/For each 3/current-item'
+                            - variable: Foreach2item
+                              $ref: '#/block/For each 2/current-item'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: TogglTrackRetrieveclients
+                              $ref: >-
+                                #/block/If 2/node-output/Toggl Track Retrieve
+                                clients/response/payload
+                            - variable: TogglTrackRetrieveclientsMetadata
+                              $ref: >-
+                                #/block/If 2/node-output/Toggl Track Retrieve
+                                clients/response
+                            - variable: TogglTrackRetrieveworkspaceprojects
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response/payload
+                            - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                              $ref: >-
+                                #/block/If/node-output/Toggl Track Retrieve
+                                workspace projects/response
+                            - variable: TogglTrackRetrievetimeentries
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response/payload
+                            - variable: TogglTrackRetrievetimeentriesMetadata
+                              $ref: >-
+                                #/node-output/Toggl Track Retrieve time
+                                entries/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 10
+                        allow-truncation: true
+                        pagination-type: SKIP_LIMIT
+                        allow-empty-output: true
+                    - if:
+                        name: If 4
+                        input:
+                          - variable: Foreach3item
+                            $ref: '#/block/For each 3/current-item'
+                          - variable: Foreach2item
+                            $ref: '#/block/For each 2/current-item'
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: QuickBooksRetrievecustomers
+                            $ref: >-
+                              #/block/If 3/node-output/QuickBooks Retrieve
+                              customers/response/payload
+                          - variable: QuickBooksRetrievecustomersMetadata
+                            $ref: >-
+                              #/block/If 3/node-output/QuickBooks Retrieve
+                              customers/response
+                          - variable: TogglTrackRetrieveclients
+                            $ref: >-
+                              #/block/If 2/node-output/Toggl Track Retrieve
+                              clients/response/payload
+                          - variable: TogglTrackRetrieveclientsMetadata
+                            $ref: >-
+                              #/block/If 2/node-output/Toggl Track Retrieve
+                              clients/response
+                          - variable: TogglTrackRetrieveworkspaceprojects
+                            $ref: >-
+                              #/block/If/node-output/Toggl Track Retrieve
+                              workspace projects/response/payload
+                          - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                            $ref: >-
+                              #/block/If/node-output/Toggl Track Retrieve
+                              workspace projects/response
+                          - variable: TogglTrackRetrievetimeentries
+                            $ref: >-
+                              #/node-output/Toggl Track Retrieve time
+                              entries/response/payload
+                          - variable: TogglTrackRetrievetimeentriesMetadata
+                            $ref: >-
+                              #/node-output/Toggl Track Retrieve time
+                              entries/response
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        branch:
+                          - condition:
+                              '{{$QuickBooksRetrievecustomersMetadata."status-code"}}': '204'
+                            execute:
+                              - create-action:
+                                  name: QuickBooks Create customer
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-5
+                                  map:
+                                    mappings:
+                                      - CompanyName:
+                                          template: '{{$Foreach3item.name}}'
+                                      - DisplayName:
+                                          template: '{{$Foreach3item.name}}'
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreach3item
+                                        $ref: '#/block/For each 3/current-item'
+                                      - variable: Foreach2item
+                                        $ref: '#/block/For each 2/current-item'
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: QuickBooksRetrievecustomers
+                                        $ref: >-
+                                          #/block/If 3/node-output/QuickBooks
+                                          Retrieve customers/response/payload
+                                      - variable: QuickBooksRetrievecustomersMetadata
+                                        $ref: >-
+                                          #/block/If 3/node-output/QuickBooks
+                                          Retrieve customers/response
+                                      - variable: TogglTrackRetrieveclients
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve clients/response/payload
+                                      - variable: TogglTrackRetrieveclientsMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve clients/response
+                                      - variable: TogglTrackRetrieveworkspaceprojects
+                                        $ref: >-
+                                          #/block/If/node-output/Toggl Track
+                                          Retrieve workspace
+                                          projects/response/payload
+                                      - variable: >-
+                                          TogglTrackRetrieveworkspaceprojectsMetadata
+                                        $ref: >-
+                                          #/block/If/node-output/Toggl Track
+                                          Retrieve workspace projects/response
+                                      - variable: TogglTrackRetrievetimeentries
+                                        $ref: >-
+                                          #/node-output/Toggl Track Retrieve time
+                                          entries/response/payload
+                                      - variable: TogglTrackRetrievetimeentriesMetadata
+                                        $ref: >-
+                                          #/node-output/Toggl Track Retrieve time
+                                          entries/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                              - create-action:
+                                  name: QuickBooks Create invoice
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-6
+                                  map:
+                                    mappings:
+                                      - CustomerRef:
+                                          mappings:
+                                            - value:
+                                                template: '{{$QuickBooksCreatecustomer.Id}}'
+                                      - Line:
+                                          mappings:
+                                            - Amount:
+                                                expression: '  $number($Foreach2item.rate ) * $Foreachitem.duration '
+                                            - DetailType:
+                                                template: SalesItemLineDetail
+                                            - SalesItemLineDetail:
+                                                mappings:
+                                                  - ServiceDate:
+                                                      template: '{{$Foreachitem.start}}'
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreach3item
+                                        $ref: '#/block/For each 3/current-item'
+                                      - variable: Foreach2item
+                                        $ref: '#/block/For each 2/current-item'
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: QuickBooksCreatecustomer
+                                        $ref: >-
+                                          #/block/If 4/node-output/QuickBooks
+                                          Create customer/response/payload
+                                      - variable: QuickBooksRetrievecustomers
+                                        $ref: >-
+                                          #/block/If 3/node-output/QuickBooks
+                                          Retrieve customers/response/payload
+                                      - variable: QuickBooksRetrievecustomersMetadata
+                                        $ref: >-
+                                          #/block/If 3/node-output/QuickBooks
+                                          Retrieve customers/response
+                                      - variable: TogglTrackRetrieveclients
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve clients/response/payload
+                                      - variable: TogglTrackRetrieveclientsMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve clients/response
+                                      - variable: TogglTrackRetrieveworkspaceprojects
+                                        $ref: >-
+                                          #/block/If/node-output/Toggl Track
+                                          Retrieve workspace
+                                          projects/response/payload
+                                      - variable: >-
+                                          TogglTrackRetrieveworkspaceprojectsMetadata
+                                        $ref: >-
+                                          #/block/If/node-output/Toggl Track
+                                          Retrieve workspace projects/response
+                                      - variable: TogglTrackRetrievetimeentries
+                                        $ref: >-
+                                          #/node-output/Toggl Track Retrieve time
+                                          entries/response/payload
+                                      - variable: TogglTrackRetrievetimeentriesMetadata
+                                        $ref: >-
+                                          #/node-output/Toggl Track Retrieve time
+                                          entries/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                        else:
+                          execute:
+                            - create-action:
+                                name: QuickBooks Create invoice 2
+                                target:
+                                  $ref: >-
+                                    #/integration/action-interfaces/action-interface-7
+                                map:
+                                  $map: http://ibm.com/appconnect/map/v1
+                                  input:
+                                    - variable: Foreach3item
+                                      $ref: '#/block/For each 3/current-item'
+                                    - variable: Foreach2item
+                                      $ref: '#/block/For each 2/current-item'
+                                    - variable: Foreachitem
+                                      $ref: '#/block/For each/current-item'
+                                    - variable: Trigger
+                                      $ref: '#/trigger/payload'
+                                    - variable: QuickBooksRetrievecustomers
+                                      $ref: >-
+                                        #/block/If 3/node-output/QuickBooks
+                                        Retrieve customers/response/payload
+                                    - variable: QuickBooksRetrievecustomersMetadata
+                                      $ref: >-
+                                        #/block/If 3/node-output/QuickBooks
+                                        Retrieve customers/response
+                                    - variable: TogglTrackRetrieveclients
+                                      $ref: >-
+                                        #/block/If 2/node-output/Toggl Track
+                                        Retrieve clients/response/payload
+                                    - variable: TogglTrackRetrieveclientsMetadata
+                                      $ref: >-
+                                        #/block/If 2/node-output/Toggl Track
+                                        Retrieve clients/response
+                                    - variable: TogglTrackRetrieveworkspaceprojects
+                                      $ref: >-
+                                        #/block/If/node-output/Toggl Track
+                                        Retrieve workspace
+                                        projects/response/payload
+                                    - variable: >-
+                                        TogglTrackRetrieveworkspaceprojectsMetadata
+                                      $ref: >-
+                                        #/block/If/node-output/Toggl Track
+                                        Retrieve workspace projects/response
+                                    - variable: TogglTrackRetrievetimeentries
+                                      $ref: >-
+                                        #/node-output/Toggl Track Retrieve time
+                                        entries/response/payload
+                                    - variable: TogglTrackRetrievetimeentriesMetadata
+                                      $ref: >-
+                                        #/node-output/Toggl Track Retrieve time
+                                        entries/response
+                                    - variable: flowDetails
+                                      $ref: '#/flowDetails'
+                                  mappings: []
+                        output-schema: {}
+              else:
+                execute: []
+              output-schema: {}
+  name: Create the invoice in Quickbooks based on billable hours tracked in Toggl Track
+models: {}

--- a/resources/Create time entries in Toggl Track for the time spent on task in Jeera.yaml
+++ b/resources/Create time entries in Toggl Track for the time spent on task in Jeera.yaml
@@ -1,0 +1,340 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: IssueCollection
+      connector-type: jira
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: getWorkspacesByWorkspaceIdProjects_model
+      connector-type: toggltrack
+      actions:
+        RETRIEVEALL: {}
+    action-interface-3:
+      type: api-action
+      business-object: postWorkspacesByWorkspaceIdProjects_model
+      connector-type: toggltrack
+      actions:
+        postWorkspacesByWorkspaceIdProjects: {}
+    action-interface-4:
+      type: api-action
+      business-object: postWorkspacesByWorkspaceIdTimeEntries_model
+      connector-type: toggltrack
+      actions:
+        postWorkspacesByWorkspaceIdTimeEntries: {}
+    action-interface-5:
+      type: api-action
+      business-object: postWorkspacesByWorkspaceIdTimeEntries_model
+      connector-type: toggltrack
+      actions:
+        postWorkspacesByWorkspaceIdTimeEntries: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Jira Retrieve all issues
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  lastModified: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$JiraRetrieveallissues '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: JiraRetrieveallissues
+                    $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                  - variable: JiraRetrieveallissuesMetadata
+                    $ref: '#/node-output/Jira Retrieve all issues/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Jira IssueCollection
+    assembly-2:
+      assembly:
+        execute:
+          - if:
+              name: If 2
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: JiraRetrieveallissues
+                  $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                - variable: JiraRetrieveallissuesMetadata
+                  $ref: '#/node-output/Jira Retrieve all issues/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem.fields.status.name}}': Completed
+                  execute:
+                    - retrieve-action:
+                        name: Toggl Track Retrieve workspace projects
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-2'
+                        filter:
+                          where:
+                            and:
+                              - name: '{{$Foreachitem.fields.project.name}}'
+                              - workspace_id: '7680400'
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: JiraRetrieveallissues
+                              $ref: >-
+                                #/node-output/Jira Retrieve all
+                                issues/response/payload
+                            - variable: JiraRetrieveallissuesMetadata
+                              $ref: '#/node-output/Jira Retrieve all issues/response'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 50
+                        allow-truncation: true
+                        pagination-type: SKIP_LIMIT
+                        allow-empty-output: true
+                    - if:
+                        name: If
+                        input:
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: TogglTrackRetrieveworkspaceprojects
+                            $ref: >-
+                              #/block/If 2/node-output/Toggl Track Retrieve
+                              workspace projects/response/payload
+                          - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                            $ref: >-
+                              #/block/If 2/node-output/Toggl Track Retrieve
+                              workspace projects/response
+                          - variable: JiraRetrieveallissues
+                            $ref: >-
+                              #/node-output/Jira Retrieve all
+                              issues/response/payload
+                          - variable: JiraRetrieveallissuesMetadata
+                            $ref: '#/node-output/Jira Retrieve all issues/response'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        branch:
+                          - condition:
+                              and:
+                                - '{{$TogglTrackRetrieveworkspaceprojectsMetadata."status-code"}}': '204'
+                                - '{{$TogglTrackRetrieveworkspaceprojectsMetadata}}':
+                                    '=': ''
+                                  hashKey: object:671
+                            execute:
+                              - custom-action:
+                                  name: Toggl Track Create workspace project
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-3
+                                  action: postWorkspacesByWorkspaceIdProjects
+                                  map:
+                                    mappings:
+                                      - active:
+                                          expression: 'true'
+                                      - billable:
+                                          expression: 'true'
+                                      - is_private:
+                                          expression: 'true'
+                                      - name:
+                                          template: '{{$Foreachitem.fields.project.name}}'
+                                      - recurring:
+                                          expression: 'false'
+                                      - workspace_id:
+                                          template: '7680400'
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: TogglTrackRetrieveworkspaceprojects
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace
+                                          projects/response/payload
+                                      - variable: >-
+                                          TogglTrackRetrieveworkspaceprojectsMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace projects/response
+                                      - variable: JiraRetrieveallissues
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response/payload
+                                      - variable: JiraRetrieveallissuesMetadata
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                              - custom-action:
+                                  name: Toggl Track Create time entry
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-4
+                                  action: postWorkspacesByWorkspaceIdTimeEntries
+                                  map:
+                                    mappings:
+                                      - billable:
+                                          expression: 'true'
+                                      - created_with:
+                                          template: >-
+                                            {{$Foreachitem.fields.issuetype.description}}
+                                      - description:
+                                          template: >-
+                                            Worked on Jeera Issue
+                                            {{$Foreachitem.id}}
+                                      - duration:
+                                          expression: '$Foreachitem.fields.timespent '
+                                      - project_id:
+                                          expression: '$TogglTrackCreateworkspaceproject.id '
+                                      - start:
+                                          template: '{{$Foreachitem.fields.created}}'
+                                      - workspace_id:
+                                          template: '7680400'
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: TogglTrackCreateworkspaceproject
+                                        $ref: >-
+                                          #/block/If/node-output/Toggl Track
+                                          Create workspace
+                                          project/response/payload
+                                      - variable: TogglTrackRetrieveworkspaceprojects
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace
+                                          projects/response/payload
+                                      - variable: >-
+                                          TogglTrackRetrieveworkspaceprojectsMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace projects/response
+                                      - variable: JiraRetrieveallissues
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response/payload
+                                      - variable: JiraRetrieveallissuesMetadata
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                        else:
+                          execute:
+                            - custom-action:
+                                name: Toggl Track Create time entry 2
+                                target:
+                                  $ref: >-
+                                    #/integration/action-interfaces/action-interface-5
+                                action: postWorkspacesByWorkspaceIdTimeEntries
+                                map:
+                                  mappings:
+                                    - billable:
+                                        expression: 'true'
+                                    - created_with:
+                                        template: >-
+                                          {{$Foreachitem.fields.issuetype.description}}
+                                    - description:
+                                        template: >-
+                                          Worked on Jeera Issue
+                                          {{$Foreachitem.id}}
+                                    - duration:
+                                        expression: '$Foreachitem.fields.timespent '
+                                    - project_id:
+                                        expression: >-
+                                          $TogglTrackRetrieveworkspaceprojects[0].id 
+                                    - start:
+                                        template: '{{$Foreachitem.fields.created}}'
+                                    - workspace_id:
+                                        template: '7680400'
+                                  $map: http://ibm.com/appconnect/map/v1
+                                  input:
+                                    - variable: Foreachitem
+                                      $ref: '#/block/For each/current-item'
+                                    - variable: Trigger
+                                      $ref: '#/trigger/payload'
+                                    - variable: TogglTrackRetrieveworkspaceprojects
+                                      $ref: >-
+                                        #/block/If 2/node-output/Toggl Track
+                                        Retrieve workspace
+                                        projects/response/payload
+                                    - variable: >-
+                                        TogglTrackRetrieveworkspaceprojectsMetadata
+                                      $ref: >-
+                                        #/block/If 2/node-output/Toggl Track
+                                        Retrieve workspace projects/response
+                                    - variable: JiraRetrieveallissues
+                                      $ref: >-
+                                        #/node-output/Jira Retrieve all
+                                        issues/response/payload
+                                    - variable: JiraRetrieveallissuesMetadata
+                                      $ref: >-
+                                        #/node-output/Jira Retrieve all
+                                        issues/response
+                                    - variable: flowDetails
+                                      $ref: '#/flowDetails'
+                        output-schema: {}
+              else:
+                execute: []
+              output-schema: {}
+  name: Create time entries in Toggl Track for the time spent on task in Jeera
+models: {}

--- a/resources/Invite new BambooHR employee for filling time entries in Toggl Track.yaml
+++ b/resources/Invite new BambooHR employee for filling time entries in Toggl Track.yaml
@@ -1,0 +1,154 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: employees
+      connector-type: bamboohr
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postOrganizationsByOrganizationIdInvitations_model
+      connector-type: toggltrack
+      actions:
+        postOrganizationsByOrganizationIdInvitations: {}
+    action-interface-3:
+      type: api-action
+      business-object: employees
+      connector-type: bamboohr
+      actions:
+        RETRIEVEALL: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: BambooHR Retrieve employees
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  since: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$BambooHRRetrieveemployees '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: BambooHR employees
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: BambooHR Retrieve employees 2
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              filter:
+                where:
+                  id: '{{$Foreachitem.id}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: false
+              allow-empty-output: false
+          - custom-action:
+              name: Toggl Track Create new invitation
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              action: postOrganizationsByOrganizationIdInvitations
+              map:
+                mappings:
+                  - emails:
+                      expression: '[$BambooHRRetrieveemployees2.workEmail ]'
+                  - organization_id:
+                      template: '7652498'
+                  - workspaces:
+                      foreach:
+                        input: '[{}]'
+                        iterator: workspacesItem
+                        mappings:
+                          - admin:
+                              expression: 'false'
+                          - workspace_id:
+                              expression: '7680400'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees2
+                    $ref: >-
+                      #/block/For each/node-output/BambooHR Retrieve employees
+                      2/response/payload
+                  - variable: BambooHRRetrieveemployees2Metadata
+                    $ref: >-
+                      #/block/For each/node-output/BambooHR Retrieve employees
+                      2/response
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Invite new BambooHR employee for filling time entries in Toggl Track
+models: {}

--- a/resources/markdown/Create the invoice in Quickbooks based on billable hours tracked in Toggl Track_instructions.md
+++ b/resources/markdown/Create the invoice in Quickbooks based on billable hours tracked in Toggl Track_instructions.md
@@ -1,0 +1,10 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Create%20the%20invoice%20in%20Quickbooks%20based%20on%20billable%20hours%20tracked%20in%20Toggl%20Track_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [Quickbooks](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-quickbooks)
+   - [Toggl Track](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-toggl-track)
+
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to create the invoice in Quickbooks based on billable hours tracked in Toggl Track.

--- a/resources/markdown/Create time entries in Toggle for the time spent on task in Jeera_instructions.md
+++ b/resources/markdown/Create time entries in Toggle for the time spent on task in Jeera_instructions.md
@@ -1,0 +1,10 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Create%20time%20entries%20in%20Toggl%20Track%20for%20the%20time%20spent%20on%20task%20in%20Jeera_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [Jira](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-jira)
+   - [Toggl Track](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-toggl-track)
+
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to create time entries in Toggl Track for the time spent on task in Jeera.

--- a/resources/markdown/Invite new BambooHR employee for filling time entries in Toggl Track_instructions.md
+++ b/resources/markdown/Invite new BambooHR employee for filling time entries in Toggl Track_instructions.md
@@ -1,0 +1,10 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Invite%20new%20BambooHR%20employee%20for%20filling%20time%20entries%20in%20Toggl%20Track_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [BambooHR](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-bamboohr)
+   - [Toggl Track](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-toggl-track)
+
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to invite new BambooHR employee for filling time entries in Toggl Track.

--- a/resources/template-metadata.json
+++ b/resources/template-metadata.json
@@ -3373,6 +3373,34 @@
     "targetApps": ["infobip", "wufoo"],
     "tags": ["streaming-connector-scheduler", "infobip", "wufoo"],
     "offerings": ["app connect professional"]
-}
+},
+    {
+    "name": "Create time entries in Toggl Track for the time spent on task in Jeera",
+    "description": "Use this template to create time entries in Toggl Track for the time spent on task in Jeera.",
+    "summary": "Scheduler to 2 applications",
+    "sourceApp": "Scheduler",
+    "targetApps": ["jira", "toggltrack"],
+    "tags": ["Scheduler","jira", "toggltrack"],
+    "offerings": ["app connect professional"]
+   },
+
+{
+    "name": "Create the invoice in Quickbooks based on billable hours tracked in Toggl Track",
+    "description": "Use this template to create the invoice in Quickbooks based on billable hours tracked in Toggl Track.",
+    "summary": "Scheduler to 2 applications",
+    "sourceApp": "Scheduler",
+    "targetApps": ["quickbooks", "toggltrack"],
+    "tags": ["Scheduler","quickbooks", "toggltrack"],
+    "offerings": ["app connect professional"]
+   },
+   {
+    "name": "Invite new BambooHR employee for filling time entries in Toggl Track",
+    "description": "Use this template to invite new BambooHR employee for filling time entries in Toggl Track.",
+    "summary": "Scheduler to 2 applications",
+    "sourceApp": "Scheduler",
+    "targetApps": ["bamboohr", "toggltrack"],
+    "tags": ["Scheduler","bamboohr", "toggltrack"],
+    "offerings": ["app connect professional"]
+   }
 ]
 }


### PR DESCRIPTION
This PR covers the yamls,netadata and markdown files for usecases of Toggl Track:
usecase1:Create time entries in Toggl Track for the time spent on task in Jeera
usecase2:Create the invoice in Quickbooks based on billable hours tracked in Toggl Track
usecase3:Invite new BambooHR employee for filling time entries in Toggl Track