### PR TITLE
usecase for Apptio

### DIFF
--- a/resources/Add employees of BambooHR to users in Apptio Targetprocess.yaml
+++ b/resources/Add employees of BambooHR to users in Apptio Targetprocess.yaml
@@ -1,0 +1,160 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: employees
+      connector-type: bamboohr
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postApiV1Users_model
+      connector-type: apptiotargetprocess
+      actions:
+        postApiV1Users: {}
+    action-interface-3:
+      type: api-action
+      business-object: employees
+      connector-type: bamboohr
+      actions:
+        RETRIEVEALL: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: BambooHR Retrieve employees
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  and:
+                    - since: '{{$Trigger.lastEventTime}}'
+                    - onlyCurrent: 'true'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 20
+              allow-truncation: true
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$BambooHRRetrieveemployees '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: BambooHR employees
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: BambooHR Retrieve employees 2
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              filter:
+                where:
+                  id: '{{$Foreachitem.id}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 1
+              allow-truncation: true
+              allow-empty-output: true
+          - custom-action:
+              name: Apptio Targetprocess Create or update user
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              action: postApiV1Users
+              map:
+                mappings:
+                  - Email:
+                      template: '{{$BambooHRRetrieveemployees2.workEmail}}'
+                  - FirstName:
+                      template: '{{$BambooHRRetrieveemployees2.firstName}}'
+                  - IsActive:
+                      expression: 'true'
+                  - IsAdministrator:
+                      expression: 'false'
+                  - LastName:
+                      template: '{{$BambooHRRetrieveemployees2.lastName}}'
+                  - LegacySkills:
+                      template: >-
+                        {{$BambooHRRetrieveemployees2.department}}{{$BambooHRRetrieveemployees2.division}}{{$BambooHRRetrieveemployees2.jobTitle}}
+                  - Login:
+                      template: '{{$BambooHRRetrieveemployees2.workEmail}}'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees2
+                    $ref: >-
+                      #/block/For each/node-output/BambooHR Retrieve employees
+                      2/response/payload
+                  - variable: BambooHRRetrieveemployees2Metadata
+                    $ref: >-
+                      #/block/For each/node-output/BambooHR Retrieve employees
+                      2/response
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              filter:
+                limit: 10
+  name: Add employees of BambooHR to users in Apptio Targetprocess
+models: {}

--- a/resources/Assign open tasks to a team from Apptio Targetprocess and send details to the team Gmail.yaml
+++ b/resources/Assign open tasks to a team from Apptio Targetprocess and send details to the team Gmail.yaml
@@ -1,0 +1,406 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: CST6CDT
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: getApiV2Tasks_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postApiV1Tasks_model
+      connector-type: apptiotargetprocess
+      actions:
+        postApiV1Tasks: {}
+    action-interface-3:
+      type: api-action
+      business-object: mail
+      connector-type: gmail
+      actions:
+        CREATE: {}
+    action-interface-4:
+      type: api-action
+      business-object: getApiV2Projects_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+    action-interface-5:
+      type: api-action
+      business-object: postApiV1Projects_model
+      connector-type: apptiotargetprocess
+      actions:
+        postApiV1Projects: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Apptio Targetprocess Retrieve tasks
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  and:
+                    - createDate:
+                        gt: '{{$Trigger.lastEventTime}}'
+                    - EntityState___Name: Open
+                    - Tags:
+                        contains: Dev 1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 5000
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ApptioTargetprocessRetrievetasks '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrievetasks
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      tasks/response/payload
+                  - variable: ApptioTargetprocessRetrievetasksMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve tasks/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                customSchemas:
+                  properties.`output`:
+                    type: object
+                    properties:
+                      TasksAssigned:
+                        type: array
+                        items:
+                          type: object
+                          properties: {}
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrieveprojects
+                    $ref: >-
+                      #/block/For each/node-output/Apptio Targetprocess Retrieve
+                      projects/response/payload
+                  - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                    $ref: >-
+                      #/block/For each/node-output/Apptio Targetprocess Retrieve
+                      projects/response
+                  - variable: ApptioTargetprocessCreateorupdatetask
+                    $ref: >-
+                      #/block/For each/node-output/Apptio Targetprocess Create
+                      or update task/response/payload
+                  - variable: ApptioTargetprocessRetrievetasks
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      tasks/response/payload
+                  - variable: ApptioTargetprocessRetrievetasksMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve tasks/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                mappings:
+                  - output:
+                      mappings:
+                        - TasksAssigned:
+                            expression: >-
+                              [ {"Task ID":
+                              $ApptioTargetprocessCreateorupdatetask.Id, "Task
+                              Name":
+                              $ApptioTargetprocessCreateorupdatetask.Name,
+                              "Project ID":
+                              $ApptioTargetprocessCreateorupdatetask._Project_.Id,
+                              "Project Name":
+                              $ApptioTargetprocessCreateorupdatetask._Project_.Name}]
+              display-name: Apptio Targetprocess Tasks
+          - if:
+              name: If
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: ApptioTargetprocessRetrievetasks
+                  $ref: >-
+                    #/node-output/Apptio Targetprocess Retrieve
+                    tasks/response/payload
+                - variable: ApptioTargetprocessRetrievetasksMetadata
+                  $ref: '#/node-output/Apptio Targetprocess Retrieve tasks/response'
+                - variable: Setvariable
+                  $ref: '#/node-output/Set variable/response/payload'
+                - variable: Foreach
+                  $ref: '#/node-output/For each/response/payload'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$count($Foreach.output.TasksAssigned )}}':
+                      gt: '0'
+                  execute:
+                    - create-action:
+                        name: Gmail Send email
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-3'
+                        map:
+                          mappings:
+                            - Body:
+                                template: |-
+                                  Assigned Task Details:
+                                  {{$Foreach.output.TasksAssigned}}
+                            - Subject:
+                                template: >-
+                                  Open Tasks are assigned to the team : Team
+                                  Charley
+                            - To:
+                                template: soaruser10@gmail.com
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ApptioTargetprocessRetrievetasks
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                tasks/response/payload
+                            - variable: ApptioTargetprocessRetrievetasksMetadata
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                tasks/response
+                            - variable: Foreach
+                              $ref: '#/node-output/For each/response/payload'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+              else:
+                execute: []
+              output-schema: {}
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Apptio Targetprocess Retrieve projects
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-4'
+              filter:
+                where:
+                  and:
+                    - Id: '{{$Foreachitem.project.id}}'
+                    - TeamProjectsName: Team Charlie
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrievetasks
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      tasks/response/payload
+                  - variable: ApptioTargetprocessRetrievetasksMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve tasks/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 1
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - if:
+              name: If 2
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: ApptioTargetprocessRetrieveprojects
+                  $ref: >-
+                    #/block/For each/node-output/Apptio Targetprocess Retrieve
+                    projects/response/payload
+                - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                  $ref: >-
+                    #/block/For each/node-output/Apptio Targetprocess Retrieve
+                    projects/response
+                - variable: ApptioTargetprocessRetrievetasks
+                  $ref: >-
+                    #/node-output/Apptio Targetprocess Retrieve
+                    tasks/response/payload
+                - variable: ApptioTargetprocessRetrievetasksMetadata
+                  $ref: '#/node-output/Apptio Targetprocess Retrieve tasks/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$ApptioTargetprocessRetrieveprojectsMetadata."status-code"}}': '204'
+                  execute:
+                    - custom-action:
+                        name: Apptio Targetprocess Create or update project
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-5'
+                        action: postApiV1Projects
+                        map:
+                          mappings:
+                            - TeamProjects:
+                                mappings:
+                                  - Items:
+                                      foreach:
+                                        input: '[{}]'
+                                        iterator: ItemsItem
+                                        mappings:
+                                          - Team:
+                                              mappings:
+                                                - Id:
+                                                    expression: '49400'
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ApptioTargetprocessRetrieveprojects
+                              $ref: >-
+                                #/block/For each/node-output/Apptio
+                                Targetprocess Retrieve projects/response/payload
+                            - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                              $ref: >-
+                                #/block/For each/node-output/Apptio
+                                Targetprocess Retrieve projects/response
+                            - variable: ApptioTargetprocessRetrievetasks
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                tasks/response/payload
+                            - variable: ApptioTargetprocessRetrievetasksMetadata
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                tasks/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                        filter:
+                          where:
+                            Id: '{{$Foreachitem.project.id}}'
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ApptioTargetprocessRetrieveprojects
+                              $ref: >-
+                                #/block/For each/node-output/Apptio
+                                Targetprocess Retrieve projects/response/payload
+                            - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                              $ref: >-
+                                #/block/For each/node-output/Apptio
+                                Targetprocess Retrieve projects/response
+                            - variable: ApptioTargetprocessRetrievetasks
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                tasks/response/payload
+                            - variable: ApptioTargetprocessRetrievetasksMetadata
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                tasks/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 10
+              else:
+                execute: []
+              output-schema: {}
+          - custom-action:
+              name: Apptio Targetprocess Create or update task
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              action: postApiV1Tasks
+              map:
+                mappings:
+                  - AssignedTeams:
+                      mappings:
+                        - Items:
+                            foreach:
+                              input: '[{}]'
+                              iterator: ItemsItem
+                              mappings:
+                                - Team:
+                                    mappings:
+                                      - Id:
+                                          expression: '49400'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrieveprojects
+                    $ref: >-
+                      #/block/For each/node-output/Apptio Targetprocess Retrieve
+                      projects/response/payload
+                  - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                    $ref: >-
+                      #/block/For each/node-output/Apptio Targetprocess Retrieve
+                      projects/response
+                  - variable: ApptioTargetprocessRetrievetasks
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      tasks/response/payload
+                  - variable: ApptioTargetprocessRetrievetasksMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve tasks/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              filter:
+                where:
+                  Id: '{{$Foreachitem.id}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrieveprojects
+                    $ref: >-
+                      #/block/For each/node-output/Apptio Targetprocess Retrieve
+                      projects/response/payload
+                  - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                    $ref: >-
+                      #/block/For each/node-output/Apptio Targetprocess Retrieve
+                      projects/response
+                  - variable: ApptioTargetprocessRetrievetasks
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      tasks/response/payload
+                  - variable: ApptioTargetprocessRetrievetasksMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve tasks/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+  name: Assign open tasks to a team from Apptio Targetprocess and send details to the team Gmail
+models: {}

--- a/resources/Create bugs in Apptio Targetprocess for the issues in Jira.yaml
+++ b/resources/Create bugs in Apptio Targetprocess for the issues in Jira.yaml
@@ -1,0 +1,351 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: IssueCollection
+      connector-type: jira
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postApiV1Bugs_model
+      connector-type: apptiotargetprocess
+      actions:
+        postApiV1Bugs: {}
+    action-interface-3:
+      type: api-action
+      business-object: getApiV2Projects_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+    action-interface-4:
+      type: api-action
+      business-object: postApiV1Projects_model
+      connector-type: apptiotargetprocess
+      actions:
+        postApiV1Projects: {}
+    action-interface-9:
+      type: api-action
+      business-object: postApiV1Bugs_model
+      connector-type: apptiotargetprocess
+      actions:
+        postApiV1Bugs: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Jira Retrieve all issues
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  created: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 500
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$JiraRetrieveallissues '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: JiraRetrieveallissues
+                    $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                  - variable: JiraRetrieveallissuesMetadata
+                    $ref: '#/node-output/Jira Retrieve all issues/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Jira IssueCollection
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Apptio Targetprocess Retrieve projects
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              filter:
+                where:
+                  Name: >-
+                    {{$Foreachitem.fields.project.id}}:{{$Foreachitem.fields.project.name}}
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: JiraRetrieveallissues
+                    $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                  - variable: JiraRetrieveallissuesMetadata
+                    $ref: '#/node-output/Jira Retrieve all issues/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 1
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - if:
+              name: If 2
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: ApptioTargetprocessRetrieveprojects
+                  $ref: >-
+                    #/block/For each/node-output/Apptio Targetprocess Retrieve
+                    projects/response/payload
+                - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                  $ref: >-
+                    #/block/For each/node-output/Apptio Targetprocess Retrieve
+                    projects/response
+                - variable: JiraRetrieveallissues
+                  $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                - variable: JiraRetrieveallissuesMetadata
+                  $ref: '#/node-output/Jira Retrieve all issues/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$ApptioTargetprocessRetrieveprojectsMetadata."status-code"}}': '200'
+                  execute:
+                    - custom-action:
+                        name: Apptio Targetprocess Create or update bug 2
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-9'
+                        action: postApiV1Bugs
+                        map:
+                          mappings:
+                            - Description:
+                                template: '{{$Foreachitem.fields.description}}'
+                            - Name:
+                                template: >-
+                                  {{$Foreachitem.id}}:
+                                  {{$Foreachitem.fields.summary}}
+                            - Project:
+                                mappings:
+                                  - Id:
+                                      expression: '$ApptioTargetprocessRetrieveprojects.id '
+                            - Tags:
+                                template: '{{$Foreachitem.fields.issuetype.name}}'
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ApptioTargetprocessRetrieveprojects
+                              $ref: >-
+                                #/block/For each/node-output/Apptio
+                                Targetprocess Retrieve projects/response/payload
+                            - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                              $ref: >-
+                                #/block/For each/node-output/Apptio
+                                Targetprocess Retrieve projects/response
+                            - variable: JiraRetrieveallissues
+                              $ref: >-
+                                #/node-output/Jira Retrieve all
+                                issues/response/payload
+                            - variable: JiraRetrieveallissuesMetadata
+                              $ref: '#/node-output/Jira Retrieve all issues/response'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                        filter:
+                          limit: 10
+                  map:
+                    $map: http://ibm.com/appconnect/map/v1
+                    input:
+                      - variable: Foreachitem
+                        $ref: '#/block/For each/current-item'
+                      - variable: Trigger
+                        $ref: '#/trigger/payload'
+                      - variable: ApptioTargetprocessCreateorupdateproject
+                        $ref: >-
+                          #/block/If 2/node-output/Apptio Targetprocess Create
+                          or update project/response/payload
+                      - variable: ApptioTargetprocessRetrieveprojects
+                        $ref: >-
+                          #/block/For each/node-output/Apptio Targetprocess
+                          Retrieve projects/response/payload
+                      - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                        $ref: >-
+                          #/block/For each/node-output/Apptio Targetprocess
+                          Retrieve projects/response
+                      - variable: Setvariable
+                        $ref: >-
+                          #/block/For each/node-output/Set
+                          variable/response/payload
+                      - variable: JiraRetrieveallissues
+                        $ref: >-
+                          #/node-output/Jira Retrieve all
+                          issues/response/payload
+                      - variable: JiraRetrieveallissuesMetadata
+                        $ref: '#/node-output/Jira Retrieve all issues/response'
+                      - variable: flowDetails
+                        $ref: '#/flowDetails'
+                    mappings:
+                      - projectid:
+                          template: '{{$ApptioTargetprocessCreateorupdateproject.Id}}'
+              else:
+                execute:
+                  - custom-action:
+                      name: Apptio Targetprocess Create or update project
+                      target:
+                        $ref: '#/integration/action-interfaces/action-interface-4'
+                      action: postApiV1Projects
+                      map:
+                        mappings:
+                          - Description:
+                              template: '{{$Foreachitem.fields.project}}'
+                          - Name:
+                              template: >-
+                                {{$Foreachitem.fields.project.id}}:{{$Foreachitem.fields.project.name}}
+                        $map: http://ibm.com/appconnect/map/v1
+                        input:
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: ApptioTargetprocessRetrieveprojects
+                            $ref: >-
+                              #/block/For each/node-output/Apptio Targetprocess
+                              Retrieve projects/response/payload
+                          - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                            $ref: >-
+                              #/block/For each/node-output/Apptio Targetprocess
+                              Retrieve projects/response
+                          - variable: JiraRetrieveallissues
+                            $ref: >-
+                              #/node-output/Jira Retrieve all
+                              issues/response/payload
+                          - variable: JiraRetrieveallissuesMetadata
+                            $ref: '#/node-output/Jira Retrieve all issues/response'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                      filter:
+                        limit: 10
+                  - custom-action:
+                      name: Apptio Targetprocess Create or update bug
+                      target:
+                        $ref: '#/integration/action-interfaces/action-interface-2'
+                      action: postApiV1Bugs
+                      map:
+                        mappings:
+                          - Description:
+                              template: '{{$Foreachitem.fields.description}}'
+                          - Name:
+                              template: >-
+                                {{$Foreachitem.id}}:
+                                {{$Foreachitem.fields.summary}}
+                          - Project:
+                              mappings:
+                                - Id:
+                                    expression: >-
+                                      $ApptioTargetprocessCreateorupdateproject.Id 
+                          - Tags:
+                              template: '{{$Foreachitem.fields.issuetype.name}}'
+                        $map: http://ibm.com/appconnect/map/v1
+                        input:
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: ApptioTargetprocessCreateorupdateproject
+                            $ref: >-
+                              #/block/If 2/node-output/Apptio Targetprocess
+                              Create or update project/response/payload
+                          - variable: ApptioTargetprocessRetrieveprojects
+                            $ref: >-
+                              #/block/For each/node-output/Apptio Targetprocess
+                              Retrieve projects/response/payload
+                          - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                            $ref: >-
+                              #/block/For each/node-output/Apptio Targetprocess
+                              Retrieve projects/response
+                          - variable: JiraRetrieveallissues
+                            $ref: >-
+                              #/node-output/Jira Retrieve all
+                              issues/response/payload
+                          - variable: JiraRetrieveallissuesMetadata
+                            $ref: '#/node-output/Jira Retrieve all issues/response'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                      filter:
+                        limit: 10
+                map:
+                  $map: http://ibm.com/appconnect/map/v1
+                  input:
+                    - variable: Foreachitem
+                      $ref: '#/block/For each/current-item'
+                    - variable: Trigger
+                      $ref: '#/trigger/payload'
+                    - variable: ApptioTargetprocessRetrieveprojects
+                      $ref: >-
+                        #/block/For each/node-output/Apptio Targetprocess
+                        Retrieve projects/response/payload
+                    - variable: ApptioTargetprocessRetrieveprojectsMetadata
+                      $ref: >-
+                        #/block/For each/node-output/Apptio Targetprocess
+                        Retrieve projects/response
+                    - variable: Setvariable
+                      $ref: >-
+                        #/block/For each/node-output/Set
+                        variable/response/payload
+                    - variable: JiraRetrieveallissues
+                      $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                    - variable: JiraRetrieveallissuesMetadata
+                      $ref: '#/node-output/Jira Retrieve all issues/response'
+                    - variable: flowDetails
+                      $ref: '#/flowDetails'
+                  mappings:
+                    - projectid:
+                        template: '{{$ApptioTargetprocessRetrieveprojects[0].Id}}'
+              output-schema:
+                type: object
+                properties:
+                  projectid:
+                    type: string
+                required: []
+  name: Create bugs in Apptio Targetprocess for the issues in Jira
+models: {}

--- a/resources/Create tickets in Zendesk Service for the bugs in Apptio Targetprocess related to IT services.yaml
+++ b/resources/Create tickets in Zendesk Service for the bugs in Apptio Targetprocess related to IT services.yaml
@@ -1,0 +1,134 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: CST6CDT
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: getApiV2Bugs_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: Ticket
+      connector-type: zendeskservice
+      actions:
+        CREATE: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Apptio Targetprocess Retrieve bugs
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  and:
+                    - createDate:
+                        gt: '{{$Trigger.lastEventTime}}'
+                    - Tags:
+                        contains: IT Services
+                    - EntityState___Name: Open
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 5000
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ApptioTargetprocessRetrievebugs '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrievebugs
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      bugs/response/payload
+                  - variable: ApptioTargetprocessRetrievebugsMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve bugs/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Apptio Targetprocess Bugs
+    assembly-2:
+      assembly:
+        execute:
+          - create-action:
+              name: Zendesk Service Create ticket
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              map:
+                mappings:
+                  - description:
+                      template: >-
+                        Apptio Targetprocess Priority:
+                        {{$Foreachitem.priority.name}},
+                        {{$Foreachitem.description}}
+                  - priority:
+                      template: normal
+                  - requester:
+                      mappings:
+                        - email:
+                            template: '{{$Foreachitem.creator.login}}'
+                        - name:
+                            template: '{{$Foreachitem.creator.fullName}}'
+                  - subject:
+                      template: '{{$Foreachitem.id}}#: {{$Foreachitem.name}}'
+                  - tags:
+                      expression: ' [$Foreachitem.tags]'
+                  - type:
+                      template: problem
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrievebugs
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      bugs/response/payload
+                  - variable: ApptioTargetprocessRetrievebugsMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve bugs/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Create tickets in Zendesk Service for the bugs in Apptio Targetprocess related to IT services
+models: {}

--- a/resources/Update Apptio Targetprocess bugs with latest status and priority from Zendesk Service tickets.yaml
+++ b/resources/Update Apptio Targetprocess bugs with latest status and priority from Zendesk Service tickets.yaml
@@ -1,0 +1,219 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+  action-interfaces:
+    action-interface-3:
+      type: api-action
+      business-object: Ticket
+      connector-type: zendeskservice
+      actions:
+        RETRIEVEALL: {}
+    action-interface-4:
+      type: api-action
+      business-object: getApiV2Bugs_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+    action-interface-5:
+      type: api-action
+      business-object: postApiV1Comments_model
+      connector-type: apptiotargetprocess
+      actions:
+        postApiV1Comments: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Zendesk Service Retrieve tickets
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              filter:
+                where:
+                  updated_at:
+                    gt: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 5000
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ZendeskServiceRetrievetickets '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ZendeskServiceRetrievetickets
+                    $ref: >-
+                      #/node-output/Zendesk Service Retrieve
+                      tickets/response/payload
+                  - variable: ZendeskServiceRetrieveticketsMetadata
+                    $ref: '#/node-output/Zendesk Service Retrieve tickets/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Zendesk Service Ticket
+    assembly-2:
+      assembly:
+        execute:
+          - if:
+              name: If
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: ZendeskServiceRetrievetickets
+                  $ref: >-
+                    #/node-output/Zendesk Service Retrieve
+                    tickets/response/payload
+                - variable: ZendeskServiceRetrieveticketsMetadata
+                  $ref: '#/node-output/Zendesk Service Retrieve tickets/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem.updated_at}}':
+                      gt: '{{$Foreachitem.created_at}}'
+                  execute:
+                    - retrieve-action:
+                        name: Apptio Targetprocess Retrieve bugs 2
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-4'
+                        filter:
+                          where:
+                            Id: '{{$split($Foreachitem.subject , "#:")[0]}}'
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ZendeskServiceRetrievetickets
+                              $ref: >-
+                                #/node-output/Zendesk Service Retrieve
+                                tickets/response/payload
+                            - variable: ZendeskServiceRetrieveticketsMetadata
+                              $ref: >-
+                                #/node-output/Zendesk Service Retrieve
+                                tickets/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 1
+                        allow-truncation: true
+                        pagination-type: SKIP_LIMIT
+                        allow-empty-output: true
+                    - if:
+                        name: If 2
+                        input:
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: ApptioTargetprocessRetrievebugs2
+                            $ref: >-
+                              #/block/If/node-output/Apptio Targetprocess
+                              Retrieve bugs 2/response/payload
+                          - variable: ApptioTargetprocessRetrievebugs2Metadata
+                            $ref: >-
+                              #/block/If/node-output/Apptio Targetprocess
+                              Retrieve bugs 2/response
+                          - variable: ZendeskServiceRetrievetickets
+                            $ref: >-
+                              #/node-output/Zendesk Service Retrieve
+                              tickets/response/payload
+                          - variable: ZendeskServiceRetrieveticketsMetadata
+                            $ref: >-
+                              #/node-output/Zendesk Service Retrieve
+                              tickets/response
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        branch:
+                          - condition:
+                              '{{$ApptioTargetprocessRetrievebugs2Metadata."status-code"}}': '200'
+                            execute:
+                              - custom-action:
+                                  name: >-
+                                    Apptio Targetprocess Create or update
+                                    comment
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-5
+                                  action: postApiV1Comments
+                                  map:
+                                    mappings:
+                                      - Description:
+                                          template: >-
+                                            Zendest ticket after the update at
+                                            {{$Foreachitem.updated_at}}: Status -
+                                            {{$Foreachitem.status}} , Priority -
+                                            {{$Foreachitem.priority}}
+                                      - General:
+                                          mappings:
+                                            - Id:
+                                                expression: $ApptioTargetprocessRetrievebugs2.id
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: ApptioTargetprocessRetrievebugs2
+                                        $ref: >-
+                                          #/block/If/node-output/Apptio
+                                          Targetprocess Retrieve bugs
+                                          2/response/payload
+                                      - variable: ApptioTargetprocessRetrievebugs2Metadata
+                                        $ref: >-
+                                          #/block/If/node-output/Apptio
+                                          Targetprocess Retrieve bugs 2/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                                  filter:
+                                    limit: 10
+                        else:
+                          execute: []
+                        output-schema: {}
+              else:
+                execute: []
+              output-schema: {}
+  name: >-
+    Update Apptio Targetprocess bugs with latest status and priority from
+    Zendesk Service tickets
+models: {}

--- a/resources/Update status of issues in Jira with the updated status from Apptio Targetprocess bugs.yaml
+++ b/resources/Update status of issues in Jira with the updated status from Apptio Targetprocess bugs.yaml
@@ -1,0 +1,221 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: CST6CDT
+  action-interfaces:
+    action-interface-5:
+      type: api-action
+      business-object: getApiV2Bugs_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+    action-interface-6:
+      type: api-action
+      business-object: Issue
+      connector-type: jira
+      actions:
+        RETRIEVEALL: {}
+    action-interface-10:
+      type: api-action
+      business-object: IssueComment
+      connector-type: jira
+      actions:
+        CREATE: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Apptio Targetprocess Retrieve bugs
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-5'
+              filter:
+                where:
+                  modifyDate:
+                    gt: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 1000
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - for-each:
+              name: For each 2
+              assembly:
+                $ref: '#/integration/assemblies/assembly-3'
+              source:
+                expression: '$ApptioTargetprocessRetrievebugs '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrievebugs
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      bugs/response/payload
+                  - variable: ApptioTargetprocessRetrievebugsMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve bugs/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Apptio Targetprocess Bugs
+    assembly-3:
+      assembly:
+        execute:
+          - if:
+              name: If 3
+              input:
+                - variable: Foreach2item
+                  $ref: '#/block/For each 2/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: ApptioTargetprocessRetrievebugs
+                  $ref: >-
+                    #/node-output/Apptio Targetprocess Retrieve
+                    bugs/response/payload
+                - variable: ApptioTargetprocessRetrievebugsMetadata
+                  $ref: '#/node-output/Apptio Targetprocess Retrieve bugs/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreach2item.modifyDate}}':
+                      gt: '{{$Foreach2item.createDate}}'
+                  execute:
+                    - retrieve-action:
+                        name: Jira Retrieve issue
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-6'
+                        filter:
+                          where:
+                            id: '{{$split($Foreach2item.name , ":")[0]}}'
+                          input:
+                            - variable: Foreach2item
+                              $ref: '#/block/For each 2/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ApptioTargetprocessRetrievebugs
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                bugs/response/payload
+                            - variable: ApptioTargetprocessRetrievebugsMetadata
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                bugs/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 1
+                        allow-truncation: true
+                        pagination-type: SKIP_LIMIT
+                        allow-empty-output: true
+                    - if:
+                        name: If 4
+                        input:
+                          - variable: Foreach2item
+                            $ref: '#/block/For each 2/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: JiraRetrieveissue
+                            $ref: >-
+                              #/block/If 3/node-output/Jira Retrieve
+                              issue/response/payload
+                          - variable: JiraRetrieveissueMetadata
+                            $ref: >-
+                              #/block/If 3/node-output/Jira Retrieve
+                              issue/response
+                          - variable: ApptioTargetprocessRetrievebugs
+                            $ref: >-
+                              #/node-output/Apptio Targetprocess Retrieve
+                              bugs/response/payload
+                          - variable: ApptioTargetprocessRetrievebugsMetadata
+                            $ref: >-
+                              #/node-output/Apptio Targetprocess Retrieve
+                              bugs/response
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        branch:
+                          - condition:
+                              '{{$JiraRetrieveissueMetadata."status-code"}}': '200'
+                            execute:
+                              - create-action:
+                                  name: Jira Create issue comment 2
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-10
+                                  map:
+                                    mappings:
+                                      - body:
+                                          template: >-
+                                            After the update at
+                                            {{$JiraRetrieveissue.fields.updated}}:
+                                            The Apptio Targetprocess Status -
+                                            {{$Foreach2item.entityState.name}} and
+                                            Priority -
+                                            {{$Foreach2item.priority.name}}
+                                      - issueId:
+                                          template: '{{$JiraRetrieveissue.id}}'
+                                      - key:
+                                          template: ITSAMPLE
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreach2item
+                                        $ref: '#/block/For each 2/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: JiraRetrieveissue
+                                        $ref: >-
+                                          #/block/If 3/node-output/Jira Retrieve
+                                          issue/response/payload
+                                      - variable: JiraRetrieveissueMetadata
+                                        $ref: >-
+                                          #/block/If 3/node-output/Jira Retrieve
+                                          issue/response
+                                      - variable: ApptioTargetprocessRetrievebugs
+                                        $ref: >-
+                                          #/node-output/Apptio Targetprocess
+                                          Retrieve bugs/response/payload
+                                      - variable: ApptioTargetprocessRetrievebugsMetadata
+                                        $ref: >-
+                                          #/node-output/Apptio Targetprocess
+                                          Retrieve bugs/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                        else:
+                          execute: []
+                        output-schema: {}
+              else:
+                execute: []
+              output-schema: {}
+  name: Update status of issues in Jira with the updated status from Apptio Targetprocess bugs
+models: {}

--- a/resources/Write comments in the issues in Jira with the new comments from Apptio Targetprocess bugs.yaml
+++ b/resources/Write comments in the issues in Jira with the new comments from Apptio Targetprocess bugs.yaml
@@ -1,0 +1,312 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: CST6CDT
+  action-interfaces:
+    action-interface-5:
+      type: api-action
+      business-object: getApiV2Bugs_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+    action-interface-6:
+      type: api-action
+      business-object: Issue
+      connector-type: jira
+      actions:
+        RETRIEVEALL: {}
+    action-interface-8:
+      type: api-action
+      business-object: IssueComment
+      connector-type: jira
+      actions:
+        CREATE: {}
+    action-interface-7:
+      type: api-action
+      business-object: getApiV2Comments_model
+      connector-type: apptiotargetprocess
+      actions:
+        RETRIEVEALL: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Apptio Targetprocess Retrieve bugs
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-5'
+              filter:
+                where:
+                  lastCommentDate:
+                    gt: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 1000
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - for-each:
+              name: For each 2
+              assembly:
+                $ref: '#/integration/assemblies/assembly-3'
+              source:
+                expression: '$ApptioTargetprocessRetrievebugs '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrievebugs
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      bugs/response/payload
+                  - variable: ApptioTargetprocessRetrievebugsMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve bugs/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Apptio Targetprocess Bugs
+    assembly-3:
+      assembly:
+        execute:
+          - if:
+              name: If 3
+              input:
+                - variable: Foreach2item
+                  $ref: '#/block/For each 2/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: ApptioTargetprocessRetrievebugs
+                  $ref: >-
+                    #/node-output/Apptio Targetprocess Retrieve
+                    bugs/response/payload
+                - variable: ApptioTargetprocessRetrievebugsMetadata
+                  $ref: '#/node-output/Apptio Targetprocess Retrieve bugs/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreach2item.lastCommentDate}}':
+                      gt: '{{$Foreach2item.createDate}}'
+                  execute:
+                    - retrieve-action:
+                        name: Jira Retrieve issue
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-6'
+                        filter:
+                          where:
+                            id: '{{$split($Foreach2item.name , ":")[0]}}'
+                          input:
+                            - variable: Foreach2item
+                              $ref: '#/block/For each 2/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ApptioTargetprocessRetrievebugs
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                bugs/response/payload
+                            - variable: ApptioTargetprocessRetrievebugsMetadata
+                              $ref: >-
+                                #/node-output/Apptio Targetprocess Retrieve
+                                bugs/response
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 1
+                        allow-truncation: true
+                        pagination-type: SKIP_LIMIT
+                        allow-empty-output: true
+                    - if:
+                        name: If 4
+                        input:
+                          - variable: Foreach2item
+                            $ref: '#/block/For each 2/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: JiraRetrieveissue
+                            $ref: >-
+                              #/block/If 3/node-output/Jira Retrieve
+                              issue/response/payload
+                          - variable: JiraRetrieveissueMetadata
+                            $ref: >-
+                              #/block/If 3/node-output/Jira Retrieve
+                              issue/response
+                          - variable: ApptioTargetprocessRetrievebugs
+                            $ref: >-
+                              #/node-output/Apptio Targetprocess Retrieve
+                              bugs/response/payload
+                          - variable: ApptioTargetprocessRetrievebugsMetadata
+                            $ref: >-
+                              #/node-output/Apptio Targetprocess Retrieve
+                              bugs/response
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        branch:
+                          - condition:
+                              '{{$JiraRetrieveissueMetadata."status-code"}}': '200'
+                            execute:
+                              - retrieve-action:
+                                  name: Apptio Targetprocess Retrieve comments
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-7
+                                  filter:
+                                    where:
+                                      and:
+                                        - General___Id: '{{$Foreach2item.id}}'
+                                        - createDate:
+                                            gt: '{{$Trigger.lastEventTime}}'
+                                    input:
+                                      - variable: Foreach2item
+                                        $ref: '#/block/For each 2/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: JiraRetrieveissue
+                                        $ref: >-
+                                          #/block/If 3/node-output/Jira Retrieve
+                                          issue/response/payload
+                                      - variable: JiraRetrieveissueMetadata
+                                        $ref: >-
+                                          #/block/If 3/node-output/Jira Retrieve
+                                          issue/response
+                                      - variable: ApptioTargetprocessRetrievebugs
+                                        $ref: >-
+                                          #/node-output/Apptio Targetprocess
+                                          Retrieve bugs/response/payload
+                                      - variable: ApptioTargetprocessRetrievebugsMetadata
+                                        $ref: >-
+                                          #/node-output/Apptio Targetprocess
+                                          Retrieve bugs/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                                    limit: 1000
+                                  allow-truncation: true
+                                  pagination-type: SKIP_LIMIT
+                                  allow-empty-output: true
+                              - for-each:
+                                  name: For each 3
+                                  assembly:
+                                    $ref: '#/integration/assemblies/assembly-4'
+                                  source:
+                                    expression: '$ApptioTargetprocessRetrievecomments '
+                                    input:
+                                      - variable: Foreach2item
+                                        $ref: '#/block/For each 2/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: ApptioTargetprocessRetrievecomments
+                                        $ref: >-
+                                          #/block/If 4/node-output/Apptio
+                                          Targetprocess Retrieve
+                                          comments/response/payload
+                                      - variable: >-
+                                          ApptioTargetprocessRetrievecommentsMetadata
+                                        $ref: >-
+                                          #/block/If 4/node-output/Apptio
+                                          Targetprocess Retrieve comments/response
+                                      - variable: JiraRetrieveissue
+                                        $ref: >-
+                                          #/block/If 3/node-output/Jira Retrieve
+                                          issue/response/payload
+                                      - variable: JiraRetrieveissueMetadata
+                                        $ref: >-
+                                          #/block/If 3/node-output/Jira Retrieve
+                                          issue/response
+                                      - variable: ApptioTargetprocessRetrievebugs
+                                        $ref: >-
+                                          #/node-output/Apptio Targetprocess
+                                          Retrieve bugs/response/payload
+                                      - variable: ApptioTargetprocessRetrievebugsMetadata
+                                        $ref: >-
+                                          #/node-output/Apptio Targetprocess
+                                          Retrieve bugs/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                                  mode: sequential
+                                  continue-on-error: true
+                                  map:
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    mappings: []
+                                  display-name: Apptio Targetprocess Comments
+                        else:
+                          execute: []
+                        output-schema: {}
+              else:
+                execute: []
+              output-schema: {}
+    assembly-4:
+      assembly:
+        execute:
+          - create-action:
+              name: Jira Create issue comment
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-8'
+              map:
+                mappings:
+                  - body:
+                      template: '{{$Foreach3item.description}}'
+                  - issueId:
+                      template: '{{$JiraRetrieveissue.id}}'
+                  - key:
+                      template: ITSAMPLE
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Foreach3item
+                    $ref: '#/block/For each 3/current-item'
+                  - variable: Foreach2item
+                    $ref: '#/block/For each 2/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ApptioTargetprocessRetrievecomments
+                    $ref: >-
+                      #/block/If 4/node-output/Apptio Targetprocess Retrieve
+                      comments/response/payload
+                  - variable: ApptioTargetprocessRetrievecommentsMetadata
+                    $ref: >-
+                      #/block/If 4/node-output/Apptio Targetprocess Retrieve
+                      comments/response
+                  - variable: JiraRetrieveissue
+                    $ref: >-
+                      #/block/If 3/node-output/Jira Retrieve
+                      issue/response/payload
+                  - variable: JiraRetrieveissueMetadata
+                    $ref: '#/block/If 3/node-output/Jira Retrieve issue/response'
+                  - variable: ApptioTargetprocessRetrievebugs
+                    $ref: >-
+                      #/node-output/Apptio Targetprocess Retrieve
+                      bugs/response/payload
+                  - variable: ApptioTargetprocessRetrievebugsMetadata
+                    $ref: '#/node-output/Apptio Targetprocess Retrieve bugs/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Write comments in the issues in Jira with the new comments from Apptio Targetprocess bugs
+models: {}


### PR DESCRIPTION
This PR covers the yaml files for usecases of Apptio:
Use case 1:
1.1Create tickets in Zendesk Service for the bugs in Apptio Targetprocess related to IT services
1.2Update Apptio Targetprocess bugs with latest status and priority from Zendesk Service tickets

Use case 2:
Assign open tasks to a team from Apptio Targetprocess and send details to the team Gmail

Use case 3:
3.1Create bugs in Apptio Targetprocess for the issues in Jira

3.2Update status of issues in Jira with the updated status from Apptio Targetprocess bugs

3.3Write comments in the issues in Jira with the new comments from Apptio Targetprocess bugs

Use case 4:
Add employees of BambooHR to users in Apptio Targetprocess