### PR TITLE
usecase for toggl track

### DIFF
--- a/resources/Create time entries in Toggl Track for each new issue created in Jira.yaml
+++ b/resources/Create time entries in Toggl Track for each new issue created in Jira.yaml
@@ -1,0 +1,340 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: IssueCollection
+      connector-type: jira
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: getWorkspacesByWorkspaceIdProjects_model
+      connector-type: toggltrack
+      actions:
+        RETRIEVEALL: {}
+    action-interface-3:
+      type: api-action
+      business-object: postWorkspacesByWorkspaceIdProjects_model
+      connector-type: toggltrack
+      actions:
+        postWorkspacesByWorkspaceIdProjects: {}
+    action-interface-4:
+      type: api-action
+      business-object: postWorkspacesByWorkspaceIdTimeEntries_model
+      connector-type: toggltrack
+      actions:
+        postWorkspacesByWorkspaceIdTimeEntries: {}
+    action-interface-5:
+      type: api-action
+      business-object: postWorkspacesByWorkspaceIdTimeEntries_model
+      connector-type: toggltrack
+      actions:
+        postWorkspacesByWorkspaceIdTimeEntries: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Jira Retrieve all issues
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  lastModified: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$JiraRetrieveallissues '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: JiraRetrieveallissues
+                    $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                  - variable: JiraRetrieveallissuesMetadata
+                    $ref: '#/node-output/Jira Retrieve all issues/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Jira issue collection
+    assembly-2:
+      assembly:
+        execute:
+          - if:
+              name: If 2
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: JiraRetrieveallissues
+                  $ref: '#/node-output/Jira Retrieve all issues/response/payload'
+                - variable: JiraRetrieveallissuesMetadata
+                  $ref: '#/node-output/Jira Retrieve all issues/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem.fields.status.name}}': Completed
+                  execute:
+                    - retrieve-action:
+                        name: Toggl Track Retrieve workspace projects
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-2'
+                        filter:
+                          where:
+                            and:
+                              - name: '{{$Foreachitem.fields.project.name}}'
+                              - workspace_id: '7680400'
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: JiraRetrieveallissues
+                              $ref: >-
+                                #/node-output/Jira Retrieve all
+                                issues/response/payload
+                            - variable: JiraRetrieveallissuesMetadata
+                              $ref: '#/node-output/Jira Retrieve all issues/response'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          limit: 50
+                        allow-truncation: true
+                        pagination-type: SKIP_LIMIT
+                        allow-empty-output: true
+                    - if:
+                        name: If
+                        input:
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: TogglTrackRetrieveworkspaceprojects
+                            $ref: >-
+                              #/block/If 2/node-output/Toggl Track Retrieve
+                              workspace projects/response/payload
+                          - variable: TogglTrackRetrieveworkspaceprojectsMetadata
+                            $ref: >-
+                              #/block/If 2/node-output/Toggl Track Retrieve
+                              workspace projects/response
+                          - variable: JiraRetrieveallissues
+                            $ref: >-
+                              #/node-output/Jira Retrieve all
+                              issues/response/payload
+                          - variable: JiraRetrieveallissuesMetadata
+                            $ref: '#/node-output/Jira Retrieve all issues/response'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        branch:
+                          - condition:
+                              and:
+                                - '{{$TogglTrackRetrieveworkspaceprojectsMetadata."status-code"}}': '204'
+                                - '{{$TogglTrackRetrieveworkspaceprojectsMetadata}}':
+                                    '=': ''
+                                  hashKey: object:671
+                            execute:
+                              - custom-action:
+                                  name: Toggl Track Create workspace project
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-3
+                                  action: postWorkspacesByWorkspaceIdProjects
+                                  map:
+                                    mappings:
+                                      - active:
+                                          expression: 'true'
+                                      - billable:
+                                          expression: 'true'
+                                      - is_private:
+                                          expression: 'true'
+                                      - name:
+                                          template: '{{$Foreachitem.fields.project.name}}'
+                                      - recurring:
+                                          expression: 'false'
+                                      - workspace_id:
+                                          template: '7680400'
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: TogglTrackRetrieveworkspaceprojects
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace
+                                          projects/response/payload
+                                      - variable: >-
+                                          TogglTrackRetrieveworkspaceprojectsMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace projects/response
+                                      - variable: JiraRetrieveallissues
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response/payload
+                                      - variable: JiraRetrieveallissuesMetadata
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                              - custom-action:
+                                  name: Toggl Track Create time entry
+                                  target:
+                                    $ref: >-
+                                      #/integration/action-interfaces/action-interface-4
+                                  action: postWorkspacesByWorkspaceIdTimeEntries
+                                  map:
+                                    mappings:
+                                      - billable:
+                                          expression: 'true'
+                                      - created_with:
+                                          template: >-
+                                            {{$Foreachitem.fields.issuetype.description}}
+                                      - description:
+                                          template: >-
+                                            Worked on Jeera Issue
+                                            {{$Foreachitem.id}}
+                                      - duration:
+                                          expression: '$Foreachitem.fields.timespent '
+                                      - project_id:
+                                          expression: '$TogglTrackCreateworkspaceproject.id '
+                                      - start:
+                                          template: '{{$Foreachitem.fields.created}}'
+                                      - workspace_id:
+                                          template: '7680400'
+                                    $map: http://ibm.com/appconnect/map/v1
+                                    input:
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
+                                      - variable: Trigger
+                                        $ref: '#/trigger/payload'
+                                      - variable: TogglTrackCreateworkspaceproject
+                                        $ref: >-
+                                          #/block/If/node-output/Toggl Track
+                                          Create workspace
+                                          project/response/payload
+                                      - variable: TogglTrackRetrieveworkspaceprojects
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace
+                                          projects/response/payload
+                                      - variable: >-
+                                          TogglTrackRetrieveworkspaceprojectsMetadata
+                                        $ref: >-
+                                          #/block/If 2/node-output/Toggl Track
+                                          Retrieve workspace projects/response
+                                      - variable: JiraRetrieveallissues
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response/payload
+                                      - variable: JiraRetrieveallissuesMetadata
+                                        $ref: >-
+                                          #/node-output/Jira Retrieve all
+                                          issues/response
+                                      - variable: flowDetails
+                                        $ref: '#/flowDetails'
+                        else:
+                          execute:
+                            - custom-action:
+                                name: Toggl Track Create time entry 2
+                                target:
+                                  $ref: >-
+                                    #/integration/action-interfaces/action-interface-5
+                                action: postWorkspacesByWorkspaceIdTimeEntries
+                                map:
+                                  mappings:
+                                    - billable:
+                                        expression: 'true'
+                                    - created_with:
+                                        template: >-
+                                          {{$Foreachitem.fields.issuetype.description}}
+                                    - description:
+                                        template: >-
+                                          Worked on Jeera Issue
+                                          {{$Foreachitem.id}}
+                                    - duration:
+                                        expression: '$Foreachitem.fields.timespent '
+                                    - project_id:
+                                        expression: >-
+                                          $TogglTrackRetrieveworkspaceprojects[0].id 
+                                    - start:
+                                        template: '{{$Foreachitem.fields.created}}'
+                                    - workspace_id:
+                                        template: '7680400'
+                                  $map: http://ibm.com/appconnect/map/v1
+                                  input:
+                                    - variable: Foreachitem
+                                      $ref: '#/block/For each/current-item'
+                                    - variable: Trigger
+                                      $ref: '#/trigger/payload'
+                                    - variable: TogglTrackRetrieveworkspaceprojects
+                                      $ref: >-
+                                        #/block/If 2/node-output/Toggl Track
+                                        Retrieve workspace
+                                        projects/response/payload
+                                    - variable: >-
+                                        TogglTrackRetrieveworkspaceprojectsMetadata
+                                      $ref: >-
+                                        #/block/If 2/node-output/Toggl Track
+                                        Retrieve workspace projects/response
+                                    - variable: JiraRetrieveallissues
+                                      $ref: >-
+                                        #/node-output/Jira Retrieve all
+                                        issues/response/payload
+                                    - variable: JiraRetrieveallissuesMetadata
+                                      $ref: >-
+                                        #/node-output/Jira Retrieve all
+                                        issues/response
+                                    - variable: flowDetails
+                                      $ref: '#/flowDetails'
+                        output-schema: {}
+              else:
+                execute: []
+              output-schema: {}
+  name: Create time entries in Toggl Track for each new issue created in Jira
+models: {}

--- a/resources/Create time entries in Toggl Track for each new issue created in Jira.yaml
+++ b/resources/Create time entries in Toggl Track for each new issue created in Jira.yaml
@@ -27,6 +27,7 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
+      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action
@@ -87,10 +88,6 @@ integration:
                 input:
                   - variable: Trigger
                     $ref: '#/trigger/payload'
-                  - variable: JiraRetrieveallissues
-                    $ref: '#/node-output/Jira Retrieve all issues/response/payload'
-                  - variable: JiraRetrieveallissuesMetadata
-                    $ref: '#/node-output/Jira Retrieve all issues/response'
                   - variable: flowDetails
                     $ref: '#/flowDetails'
               mode: sequential
@@ -105,14 +102,10 @@ integration:
           - if:
               name: If 2
               input:
-                - variable: Foreachitem
-                  $ref: '#/block/For each/current-item'
                 - variable: Trigger
                   $ref: '#/trigger/payload'
-                - variable: JiraRetrieveallissues
-                  $ref: '#/node-output/Jira Retrieve all issues/response/payload'
-                - variable: JiraRetrieveallissuesMetadata
-                  $ref: '#/node-output/Jira Retrieve all issues/response'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
                 - variable: flowDetails
                   $ref: '#/flowDetails'
               branch:
@@ -148,24 +141,10 @@ integration:
                     - if:
                         name: If
                         input:
-                          - variable: Foreachitem
-                            $ref: '#/block/For each/current-item'
                           - variable: Trigger
                             $ref: '#/trigger/payload'
-                          - variable: TogglTrackRetrieveworkspaceprojects
-                            $ref: >-
-                              #/block/If 2/node-output/Toggl Track Retrieve
-                              workspace projects/response/payload
-                          - variable: TogglTrackRetrieveworkspaceprojectsMetadata
-                            $ref: >-
-                              #/block/If 2/node-output/Toggl Track Retrieve
-                              workspace projects/response
-                          - variable: JiraRetrieveallissues
-                            $ref: >-
-                              #/node-output/Jira Retrieve all
-                              issues/response/payload
-                          - variable: JiraRetrieveallissuesMetadata
-                            $ref: '#/node-output/Jira Retrieve all issues/response'
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
                           - variable: flowDetails
                             $ref: '#/flowDetails'
                         branch:
@@ -198,28 +177,10 @@ integration:
                                           template: '7680400'
                                     $map: http://ibm.com/appconnect/map/v1
                                     input:
-                                      - variable: Foreachitem
-                                        $ref: '#/block/For each/current-item'
                                       - variable: Trigger
                                         $ref: '#/trigger/payload'
-                                      - variable: TogglTrackRetrieveworkspaceprojects
-                                        $ref: >-
-                                          #/block/If 2/node-output/Toggl Track
-                                          Retrieve workspace
-                                          projects/response/payload
-                                      - variable: >-
-                                          TogglTrackRetrieveworkspaceprojectsMetadata
-                                        $ref: >-
-                                          #/block/If 2/node-output/Toggl Track
-                                          Retrieve workspace projects/response
-                                      - variable: JiraRetrieveallissues
-                                        $ref: >-
-                                          #/node-output/Jira Retrieve all
-                                          issues/response/payload
-                                      - variable: JiraRetrieveallissuesMetadata
-                                        $ref: >-
-                                          #/node-output/Jira Retrieve all
-                                          issues/response
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
                                       - variable: flowDetails
                                         $ref: '#/flowDetails'
                               - custom-action:
@@ -249,33 +210,10 @@ integration:
                                           template: '7680400'
                                     $map: http://ibm.com/appconnect/map/v1
                                     input:
-                                      - variable: Foreachitem
-                                        $ref: '#/block/For each/current-item'
                                       - variable: Trigger
                                         $ref: '#/trigger/payload'
-                                      - variable: TogglTrackCreateworkspaceproject
-                                        $ref: >-
-                                          #/block/If/node-output/Toggl Track
-                                          Create workspace
-                                          project/response/payload
-                                      - variable: TogglTrackRetrieveworkspaceprojects
-                                        $ref: >-
-                                          #/block/If 2/node-output/Toggl Track
-                                          Retrieve workspace
-                                          projects/response/payload
-                                      - variable: >-
-                                          TogglTrackRetrieveworkspaceprojectsMetadata
-                                        $ref: >-
-                                          #/block/If 2/node-output/Toggl Track
-                                          Retrieve workspace projects/response
-                                      - variable: JiraRetrieveallissues
-                                        $ref: >-
-                                          #/node-output/Jira Retrieve all
-                                          issues/response/payload
-                                      - variable: JiraRetrieveallissuesMetadata
-                                        $ref: >-
-                                          #/node-output/Jira Retrieve all
-                                          issues/response
+                                      - variable: Foreachitem
+                                        $ref: '#/block/For each/current-item'
                                       - variable: flowDetails
                                         $ref: '#/flowDetails'
                         else:
@@ -308,28 +246,10 @@ integration:
                                         template: '7680400'
                                   $map: http://ibm.com/appconnect/map/v1
                                   input:
-                                    - variable: Foreachitem
-                                      $ref: '#/block/For each/current-item'
                                     - variable: Trigger
                                       $ref: '#/trigger/payload'
-                                    - variable: TogglTrackRetrieveworkspaceprojects
-                                      $ref: >-
-                                        #/block/If 2/node-output/Toggl Track
-                                        Retrieve workspace
-                                        projects/response/payload
-                                    - variable: >-
-                                        TogglTrackRetrieveworkspaceprojectsMetadata
-                                      $ref: >-
-                                        #/block/If 2/node-output/Toggl Track
-                                        Retrieve workspace projects/response
-                                    - variable: JiraRetrieveallissues
-                                      $ref: >-
-                                        #/node-output/Jira Retrieve all
-                                        issues/response/payload
-                                    - variable: JiraRetrieveallissuesMetadata
-                                      $ref: >-
-                                        #/node-output/Jira Retrieve all
-                                        issues/response
+                                    - variable: Foreachitem
+                                      $ref: '#/block/For each/current-item'
                                     - variable: flowDetails
                                       $ref: '#/flowDetails'
                         output-schema: {}

--- a/resources/Create time entries in Toggl Track for each new issue created in Jira.yaml
+++ b/resources/Create time entries in Toggl Track for each new issue created in Jira.yaml
@@ -27,7 +27,6 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
-      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.yaml
+++ b/resources/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.yaml
@@ -27,6 +27,7 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
+      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action
@@ -74,10 +75,6 @@ integration:
                 input:
                   - variable: Trigger
                     $ref: '#/trigger/payload'
-                  - variable: BambooHRRetrieveemployees
-                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
-                  - variable: BambooHRRetrieveemployeesMetadata
-                    $ref: '#/node-output/BambooHR Retrieve employees/response'
                   - variable: flowDetails
                     $ref: '#/flowDetails'
               mode: sequential
@@ -132,23 +129,13 @@ integration:
                               expression: '7680400'
                 $map: http://ibm.com/appconnect/map/v1
                 input:
-                  - variable: Foreachitem
-                    $ref: '#/block/For each/current-item'
                   - variable: Trigger
                     $ref: '#/trigger/payload'
-                  - variable: BambooHRRetrieveemployees2
-                    $ref: >-
-                      #/block/For each/node-output/BambooHR Retrieve employees
-                      2/response/payload
-                  - variable: BambooHRRetrieveemployees2Metadata
-                    $ref: >-
-                      #/block/For each/node-output/BambooHR Retrieve employees
-                      2/response
-                  - variable: BambooHRRetrieveemployees
-                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
-                  - variable: BambooHRRetrieveemployeesMetadata
-                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
                   - variable: flowDetails
                     $ref: '#/flowDetails'
-  name: Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR
+  name: >-
+    Send an invite to fill time entries in Toggl Track for each new employee
+    added to BambooHR
 models: {}

--- a/resources/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.yaml
+++ b/resources/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.yaml
@@ -27,7 +27,6 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
-      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.yaml
+++ b/resources/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.yaml
@@ -1,0 +1,154 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: employees
+      connector-type: bamboohr
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postOrganizationsByOrganizationIdInvitations_model
+      connector-type: toggltrack
+      actions:
+        postOrganizationsByOrganizationIdInvitations: {}
+    action-interface-3:
+      type: api-action
+      business-object: employees
+      connector-type: bamboohr
+      actions:
+        RETRIEVEALL: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: BambooHR Retrieve employees
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  since: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$BambooHRRetrieveemployees '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: BambooHR employees
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: BambooHR Retrieve employees 2
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              filter:
+                where:
+                  id: '{{$Foreachitem.id}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: false
+              allow-empty-output: false
+          - custom-action:
+              name: Toggl Track Create new invitation
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              action: postOrganizationsByOrganizationIdInvitations
+              map:
+                mappings:
+                  - emails:
+                      expression: '[$BambooHRRetrieveemployees2.workEmail ]'
+                  - organization_id:
+                      template: '7652498'
+                  - workspaces:
+                      foreach:
+                        input: '[{}]'
+                        iterator: workspacesItem
+                        mappings:
+                          - admin:
+                              expression: 'false'
+                          - workspace_id:
+                              expression: '7680400'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: BambooHRRetrieveemployees2
+                    $ref: >-
+                      #/block/For each/node-output/BambooHR Retrieve employees
+                      2/response/payload
+                  - variable: BambooHRRetrieveemployees2Metadata
+                    $ref: >-
+                      #/block/For each/node-output/BambooHR Retrieve employees
+                      2/response
+                  - variable: BambooHRRetrieveemployees
+                    $ref: '#/node-output/BambooHR Retrieve employees/response/payload'
+                  - variable: BambooHRRetrieveemployeesMetadata
+                    $ref: '#/node-output/BambooHR Retrieve employees/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR
+models: {}

--- a/resources/markdown/Create time entries in Toggl Track for each new issue created in Jira_instructions.md
+++ b/resources/markdown/Create time entries in Toggl Track for each new issue created in Jira_instructions.md
@@ -1,10 +1,8 @@
 To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Create%20time%20entries%20in%20Toggl%20Track%20for%20each%20new%20issue%20created%20in%20Jira_instructions.md) (opens in a new window).
-
 1. Click **Use this template** to start using the template.
 2. Connect to the following accounts by using your credentials:
    - [Jira](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-jira)
    - [Toggl Track](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-toggl-track)
-
 3. To start the flow, in the banner click **Start flow**.
 
 Use this template to create time entries in Toggl Track for each new issue created in Jira.

--- a/resources/markdown/Create time entries in Toggl Track for each new issue created in Jira_instructions.md
+++ b/resources/markdown/Create time entries in Toggl Track for each new issue created in Jira_instructions.md
@@ -1,0 +1,10 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Create%20time%20entries%20in%20Toggl%20Track%20for%20each%20new%20issue%20created%20in%20Jira_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [Jira](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-jira)
+   - [Toggl Track](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-toggl-track)
+
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to create time entries in Toggl Track for each new issue created in Jira.

--- a/resources/markdown/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR_instructions.md
+++ b/resources/markdown/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR_instructions.md
@@ -1,10 +1,8 @@
 To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Send%20an%20invite%20to%20fill%20time%20entries%20in%20Toggl%20Track%20for%20each%20new%20employee%20added%20to%20BambooHR_instructions.md) (opens in a new window).
-
 1. Click **Use this template** to start using the template.
 2. Connect to the following accounts by using your credentials:
    - [BambooHR](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-bamboohr)
    - [Toggl Track](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-toggl-track)
-
 3. To start the flow, in the banner click **Start flow**.
 
 Use this template to send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.

--- a/resources/markdown/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR_instructions.md
+++ b/resources/markdown/Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR_instructions.md
@@ -1,0 +1,10 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Send%20an%20invite%20to%20fill%20time%20entries%20in%20Toggl%20Track%20for%20each%20new%20employee%20added%20to%20BambooHR_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [BambooHR](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-bamboohr)
+   - [Toggl Track](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-toggl-track)
+
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.

--- a/resources/template-metadata.json
+++ b/resources/template-metadata.json
@@ -3373,6 +3373,24 @@
     "targetApps": ["infobip", "wufoo"],
     "tags": ["streaming-connector-scheduler", "infobip", "wufoo"],
     "offerings": ["app connect professional"]
-}
+},
+    {
+    "name": "Create time entries in Toggl Track for each new issue created in Jira",
+    "description": "Use this template to create time entries in Toggl Track for each new issue created in Jira.",
+    "summary": "Scheduler to 2 applications",
+    "sourceApp": "streaming-connector-scheduler",
+    "targetApps": ["jira", "toggltrack"],
+    "tags": ["streaming-connector-scheduler","jira", "toggltrack"],
+    "offerings": ["app connect professional"]
+   },
+   {
+    "name": "Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR",
+    "description": "Use this template to send an invite to fill time entries in Toggl Track for each new employee added to BambooHR.",
+    "summary": "Scheduler to 2 applications",
+    "sourceApp": "streaming-connector-scheduler",
+    "targetApps": ["bamboohr", "toggltrack"],
+    "tags": ["streaming-connector-scheduler","bamboohr", "toggltrack"],
+    "offerings": ["app connect professional"]
+   }
 ]
 }


### PR DESCRIPTION
This PR covers the yamls,netadata and markdown files for usecases of Toggl Track:
usecase1:Create time entries in Toggl Track for each new issue created in Jira
usecase3:Send an invite to fill time entries in Toggl Track for each new employee added to BambooHR