### PR TITLE
usecase for clicksend

### DIFF
--- a/resources/Send a voice message through ClickSend for each new form entry created in Wufoo.yaml
+++ b/resources/Send a voice message through ClickSend for each new form entry created in Wufoo.yaml
@@ -27,7 +27,6 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
-      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Send a voice message through ClickSend for each new form entry created in Wufoo.yaml
+++ b/resources/Send a voice message through ClickSend for each new form entry created in Wufoo.yaml
@@ -27,6 +27,7 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
+      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Send a voice message through ClickSend for each new form entry created in Wufoo.yaml
+++ b/resources/Send a voice message through ClickSend for each new form entry created in Wufoo.yaml
@@ -1,0 +1,171 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: FormEntry
+      connector-type: wufoo
+      actions:
+        RETRIEVEALL: {}
+    action-interface-3:
+      type: api-action
+      business-object: postListsByContactListIdContacts_model
+      connector-type: clicksend
+      actions:
+        postListsByContactListIdContacts: {}
+    action-interface-4:
+      type: api-action
+      business-object: postVoiceSend_model
+      connector-type: clicksend
+      actions:
+        postVoiceSend: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Wufoo Retrieve form entries
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  Hash: mukt2z50f8lvnu
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$WufooRetrieveformentries '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Wufoo form entry
+        tags:
+          - incomplete
+    assembly-2:
+      assembly:
+        execute:
+          - if:
+              name: If
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem.DateCreated}}':
+                      gt: '{{$Trigger.lastEventTime}}'
+                  execute:
+                    - custom-action:
+                        name: ClickSend Create contact in contact list
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-3'
+                        action: postListsByContactListIdContacts
+                        map:
+                          mappings:
+                            - address_line_1:
+                                template: Address line 1
+                            - contactListId:
+                                template: '2321040'
+                            - email:
+                                template: '{{$Foreachitem.Field4}}'
+                            - first_name:
+                                template: '{{$Foreachitem.Field1}}'
+                            - last_name:
+                                template: '{{$Foreachitem.Field2}}'
+                            - phone_number:
+                                template: '{{$Foreachitem.Field3}}'
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                    - custom-action:
+                        name: ClickSend Send voice message
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-4'
+                        action: postVoiceSend
+                        map:
+                          mappings:
+                            - messages:
+                                foreach:
+                                  input: '{}'
+                                  iterator: messagesItem
+                                  mappings:
+                                    - body:
+                                        template: >-
+                                          Welcome to our page. Thank you for
+                                          signing up. We have many more products
+                                          in the shop.
+                                    - custom_string:
+                                        template: test
+                                    - lang:
+                                        template: en-us
+                                    - to:
+                                        template: '{{$Foreachitem.Field3}}'
+                                    - voice:
+                                        template: male
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+              else:
+                execute: []
+              output-schema: {}
+  name: >-
+    Send a voice message through ClickSend for each new form entry created in
+    Wufoo
+models: {}

--- a/resources/Send an SMS message through ClickSend for each complaint received through Gmail.yaml
+++ b/resources/Send an SMS message through ClickSend for each complaint received through Gmail.yaml
@@ -1,0 +1,123 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        CREATED:
+          input-context:
+            data: mail
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options: {}
+      connector-type: gmail
+  action-interfaces:
+    action-interface-2:
+      type: api-action
+      business-object: postSmsSend_model
+      connector-type: clicksend
+      actions:
+        postSmsSend: {}
+    action-interface-1:
+      type: api-action
+      business-object: getListsByListIdContacts_model
+      connector-type: clicksend
+      actions:
+        RETRIEVEALL: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: ClickSend Retrieve contacts by list ID
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  list_id: '2321040'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 1000
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ClickSendRetrievecontactsbylistID '
+                input:
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: ClickSend contacts
+        tags:
+          - incomplete
+    assembly-2:
+      assembly:
+        execute:
+          - if:
+              name: If
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Trigger.From}}': '{{$Foreachitem.email}}'
+                  execute:
+                    - custom-action:
+                        name: ClickSend Send SMS message
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-2'
+                        action: postSmsSend
+                        map:
+                          mappings:
+                            - messages:
+                                foreach:
+                                  input: '{}'
+                                  iterator: messagesItem
+                                  mappings:
+                                    - body:
+                                        template: >-
+                                          Your complaint has been received and is
+                                          currently in an active state.
+                                    - from:
+                                        template: '+61447254068'
+                                    - source:
+                                        template: Gmail Complain
+                                    - to:
+                                        template: '{{$Foreachitem.phone_number}}'
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                  completion-action:
+                    terminate:
+                      info:
+                        input:
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        message: Contact found
+                        status-code: 200
+              else:
+                execute: []
+              output-schema: {}
+  name: >-
+    Send an SMS message through ClickSend for each complaint received through
+    Gmail
+models: {}

--- a/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
+++ b/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
@@ -27,20 +27,17 @@ integration:
                     - SAT
                     - SUN
                   timeZone: UTC
-      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action
       business-object: order
       connector-type: shopify
-      account-name: Account 1
       actions:
         RETRIEVEALL: {}
     action-interface-2:
       type: api-action
       business-object: postSmsSend_model
       connector-type: clicksend
-      account-name: Account 1
       actions:
         postSmsSend: {}
   assemblies:

--- a/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
+++ b/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
@@ -27,6 +27,7 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
+      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
+++ b/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
@@ -4,18 +4,19 @@ integration:
   trigger-interfaces:
     trigger-interface-1:
       type: event-trigger
+      connector-type: streaming-connector-scheduler
       triggers:
         SCHEDULE:
-          input-context:
-            data: scheduler
           assembly:
             $ref: '#/integration/assemblies/assembly-1'
+          input-context:
+            data: scheduler
           options:
             subscription:
               scheduleConfiguration:
                 interval:
                   unit: minute
-                  value: 2
+                  value: 1
                   runOnceOncheck: true
                   days:
                     - MON
@@ -26,49 +27,38 @@ integration:
                     - SAT
                     - SUN
                   timeZone: UTC
-      connector-type: streaming-connector-scheduler
       account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action
       business-object: order
       connector-type: shopify
+      account-name: Account 1
       actions:
         RETRIEVEALL: {}
-      account-name: Account 1
-    action-interface-3:
+    action-interface-2:
       type: api-action
       business-object: postSmsSend_model
       connector-type: clicksend
+      account-name: Account 1
       actions:
         postSmsSend: {}
-      account-name: Account 1
   assemblies:
     assembly-1:
       assembly:
         execute:
           - retrieve-action:
+              allow-empty-output: false
+              allow-truncation: true
               name: Shopify Retrieve orders
               target:
                 $ref: '#/integration/action-interfaces/action-interface-1'
               filter:
-                where:
-                  and:
-                    - status: open
-                    - created_at_min: '{{$Trigger.lastEventTime}}'
-                input:
-                  - variable: Trigger
-                    $ref: '#/trigger/payload'
-                  - variable: flowDetails
-                    $ref: '#/flowDetails'
-                limit: 2
-              allow-truncation: true
-              pagination-type: TOKEN
-              allow-empty-output: false
+                limit: 10
           - for-each:
-              name: For each
-              assembly:
-                $ref: '#/integration/assemblies/assembly-2'
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
               source:
                 expression: '$ShopifyRetrieveorders '
                 input:
@@ -82,23 +72,23 @@ integration:
                     $ref: '#/flowDetails'
               mode: sequential
               continue-on-error: true
-              map:
-                $map: http://ibm.com/appconnect/map/v1
-                mappings: []
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
               display-name: Shopify order
     assembly-2:
       assembly:
         execute:
           - custom-action:
+              action: postSmsSend
               name: ClickSend Send SMS message
               target:
-                $ref: '#/integration/action-interfaces/action-interface-3'
-              action: postSmsSend
+                $ref: '#/integration/action-interfaces/action-interface-2'
               map:
                 mappings:
                   - messages:
                       foreach:
-                        input: '{}'
+                        input: '[]'
                         iterator: messagesItem
                         mappings:
                           - body:

--- a/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
+++ b/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
@@ -1,0 +1,118 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 2
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: order
+      connector-type: shopify
+      actions:
+        RETRIEVEALL: {}
+    action-interface-3:
+      type: api-action
+      business-object: postSmsSend_model
+      connector-type: clicksend
+      actions:
+        postSmsSend: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Shopify Retrieve orders
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  and:
+                    - status: open
+                    - created_at_min: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 1
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ShopifyRetrieveorders  '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Shopify order
+    assembly-2:
+      assembly:
+        execute:
+          - custom-action:
+              name: ClickSend Send SMS message
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              action: postSmsSend
+              map:
+                mappings:
+                  - messages:
+                      foreach:
+                        input: '{}'
+                        iterator: messagesItem
+                        mappings:
+                          - body:
+                              template: >-
+                                Your Order has been placed. Order ID
+                                is:{{$Foreachitem.id}}
+                          - custom_string:
+                              template: test
+                          - from:
+                              template: '+61411111111'
+                          - source:
+                              template: Shopify Order
+                          - to:
+                              template: '{{$Foreachitem.shipping_address.phone}}'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Send an SMS message through ClickSend for each order placed in Shopify
+models: {}

--- a/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
+++ b/resources/Send an SMS message through ClickSend for each order placed in Shopify.yaml
@@ -35,12 +35,14 @@ integration:
       connector-type: shopify
       actions:
         RETRIEVEALL: {}
+      account-name: Account 1
     action-interface-3:
       type: api-action
       business-object: postSmsSend_model
       connector-type: clicksend
       actions:
         postSmsSend: {}
+      account-name: Account 1
   assemblies:
     assembly-1:
       assembly:
@@ -59,7 +61,7 @@ integration:
                     $ref: '#/trigger/payload'
                   - variable: flowDetails
                     $ref: '#/flowDetails'
-                limit: 1
+                limit: 2
               allow-truncation: true
               pagination-type: TOKEN
               allow-empty-output: false
@@ -68,10 +70,14 @@ integration:
               assembly:
                 $ref: '#/integration/assemblies/assembly-2'
               source:
-                expression: '$ShopifyRetrieveorders  '
+                expression: '$ShopifyRetrieveorders '
                 input:
                   - variable: Trigger
                     $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrieveorders
+                    $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                  - variable: ShopifyRetrieveordersMetadata
+                    $ref: '#/node-output/Shopify Retrieve orders/response'
                   - variable: flowDetails
                     $ref: '#/flowDetails'
               mode: sequential
@@ -111,6 +117,10 @@ integration:
                 input:
                   - variable: Trigger
                     $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrieveorders
+                    $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                  - variable: ShopifyRetrieveordersMetadata
+                    $ref: '#/node-output/Shopify Retrieve orders/response'
                   - variable: Foreachitem
                     $ref: '#/block/For each/current-item'
                   - variable: flowDetails


### PR DESCRIPTION
This PR covers the yaml files for usecases of Clicksend:
usecase1:Send an SMS message through ClickSend for each order placed in Shopify.
1.1: Send confirmation sms notification, when customer place any order.
1.2: Send thank you message with feedback link to the customers after order is generated in e commerce site.
1.3: Create package in zoho inventory for order generated in e commerce, send sms notification to customer about the package is ready to ship.

usecase2:Send an SMS message through ClickSend for each complaint received through Gmail.

usecase3:Send a voice message through ClickSend for each new form entry created in Wufoo.