### PR TITLE
usecase for FactorialHR

### DIFF
--- a/resources/Create event in Google Calendar for applied leave in Factorial HR.yaml
+++ b/resources/Create event in Google Calendar for applied leave in Factorial HR.yaml
@@ -1,0 +1,159 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: getApiV1TimeLeaves_model
+      connector-type: factorialhr
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: events
+      connector-type: googlecalendar
+      actions:
+        CREATE: {}
+    action-interface-3:
+      type: api-action
+      business-object: getApiV1EmployeesById_model
+      connector-type: factorialhr
+      actions:
+        getApiV1EmployeesById: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Factorial HR Retrieve absences
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  from:
+                    gte: '{{$split($Trigger.lastEventTime   , "T")[0]}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$FactorialHRRetrieveabsences '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Absences
+    assembly-2:
+      assembly:
+        execute:
+          - custom-action:
+              name: Factorial HR Retrieve employees by employee ID
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              action: getApiV1EmployeesById
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                mappings: []
+              filter:
+                where:
+                  id: '{{$Foreachitem.employee_id}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: FactorialHRRetrieveabsences
+                    $ref: >-
+                      #/node-output/Factorial HR Retrieve
+                      absences/response/payload
+                  - variable: FactorialHRRetrieveabsencesMetadata
+                    $ref: '#/node-output/Factorial HR Retrieve absences/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+          - create-action:
+              name: Google Calendar Create event
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              map:
+                mappings:
+                  - attendees:
+                      foreach:
+                        input: '[{}]'
+                        iterator: attendeesItem
+                        mappings:
+                          - displayName:
+                              template: '{{$Foreachitem.employee_full_name}}'
+                          - email:
+                              template: >-
+                                {{$FactorialHRRetrieveemployeesbyemployeeID.email}}
+                          - id:
+                              template: '{{$Foreachitem.employee_id}}'
+                  - description:
+                      template: '{{$Foreachitem.description}}'
+                  - endTime:
+                      template: '{{$Foreachitem.finish_on}}'
+                  - id:
+                      template: >-
+                        20339a4660b19dc14009342413b68d3ae1584ecbcbf4dd0fcd1641a9a05b177f@group.calendar.google.com
+                  - startTime:
+                      template: '{{$Foreachitem.start_on}}'
+                  - summary:
+                      template: '{{$Foreachitem.leave_type_name}}'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Create event in Google Calendar for applied leave in Factorial HR
+models: {}

--- a/resources/Seamless sync time entries between Factorial HR and Toggl Track.yaml
+++ b/resources/Seamless sync time entries between Factorial HR and Toggl Track.yaml
@@ -1,0 +1,282 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: true
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+  action-interfaces:
+    action-interface-2:
+      type: api-action
+      business-object: postWorkspacesByWorkspaceIdTimeEntries_model
+      connector-type: toggltrack
+      actions:
+        postWorkspacesByWorkspaceIdTimeEntries: {}
+    action-interface-3:
+      type: api-action
+      business-object: getWorkspacesByWorkspaceIdProjects_model
+      connector-type: toggltrack
+      actions:
+        RETRIEVEALL: {}
+    action-interface-4:
+      type: api-action
+      business-object: getApiV1TimeShifts_model
+      connector-type: factorialhr
+      actions:
+        RETRIEVEALL: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Factorial HR Retrieve shifts
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-4'
+              filter:
+                where:
+                  and:
+                    - year: '{{$split($Trigger.lastEventTime , "-")[0]}}'
+                    - month: '{{$split($Trigger.lastEventTime , "-")[1]}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$FactorialHRRetrieveshifts '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Time registries
+    assembly-2:
+      assembly:
+        execute:
+          - if:
+              name: If
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem._month_}}':
+                      lt: '10'
+                  execute: []
+                  map:
+                    $map: http://ibm.com/appconnect/map/v1
+                    input:
+                      - variable: Foreachitem
+                        $ref: '#/block/For each/current-item'
+                      - variable: Trigger
+                        $ref: '#/trigger/payload'
+                      - variable: FactorialHRRetrievetimeregistries
+                        $ref: >-
+                          #/node-output/Factorial HR Retrieve time
+                          registries/response/payload
+                      - variable: FactorialHRRetrievetimeregistriesMetadata
+                        $ref: >-
+                          #/node-output/Factorial HR Retrieve time
+                          registries/response
+                      - variable: flowDetails
+                        $ref: '#/flowDetails'
+                    mappings:
+                      - NewMonth:
+                          template: 0{{$Foreachitem._month_}}
+              else:
+                execute: []
+                map:
+                  $map: http://ibm.com/appconnect/map/v1
+                  input:
+                    - variable: Foreachitem
+                      $ref: '#/block/For each/current-item'
+                    - variable: Trigger
+                      $ref: '#/trigger/payload'
+                    - variable: FactorialHRRetrievetimeregistries
+                      $ref: >-
+                        #/node-output/Factorial HR Retrieve time
+                        registries/response/payload
+                    - variable: FactorialHRRetrievetimeregistriesMetadata
+                      $ref: >-
+                        #/node-output/Factorial HR Retrieve time
+                        registries/response
+                    - variable: flowDetails
+                      $ref: '#/flowDetails'
+                  mappings:
+                    - NewMonth:
+                        template: '{{$Foreachitem._month_}}'
+              output-schema:
+                type: object
+                properties:
+                  NewMonth:
+                    type: string
+                required: []
+          - if:
+              name: If 2
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: If
+                  $ref: '#/block/For each/node-output/If/response/payload'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$Foreachitem.day}}':
+                      lt: '10'
+                  execute: []
+                  map:
+                    $map: http://ibm.com/appconnect/map/v1
+                    input:
+                      - variable: Foreachitem
+                        $ref: '#/block/For each/current-item'
+                      - variable: Trigger
+                        $ref: '#/trigger/payload'
+                      - variable: If
+                        $ref: '#/block/For each/node-output/If/response/payload'
+                      - variable: FactorialHRRetrievetimeregistries
+                        $ref: >-
+                          #/node-output/Factorial HR Retrieve time
+                          registries/response/payload
+                      - variable: FactorialHRRetrievetimeregistriesMetadata
+                        $ref: >-
+                          #/node-output/Factorial HR Retrieve time
+                          registries/response
+                      - variable: flowDetails
+                        $ref: '#/flowDetails'
+                    mappings:
+                      - NewDate:
+                          template: 0{{$Foreachitem.day}}
+              else:
+                execute: []
+                map:
+                  $map: http://ibm.com/appconnect/map/v1
+                  input:
+                    - variable: Foreachitem
+                      $ref: '#/block/For each/current-item'
+                    - variable: Trigger
+                      $ref: '#/trigger/payload'
+                    - variable: If
+                      $ref: '#/block/For each/node-output/If/response/payload'
+                    - variable: FactorialHRRetrievetimeregistries
+                      $ref: >-
+                        #/node-output/Factorial HR Retrieve time
+                        registries/response/payload
+                    - variable: FactorialHRRetrievetimeregistriesMetadata
+                      $ref: >-
+                        #/node-output/Factorial HR Retrieve time
+                        registries/response
+                    - variable: flowDetails
+                      $ref: '#/flowDetails'
+                  mappings:
+                    - NewDate:
+                        template: '{{$Foreachitem.day}}'
+              output-schema:
+                type: object
+                properties:
+                  NewDate:
+                    type: string
+                required: []
+          - retrieve-action:
+              name: Toggl Track Retrieve workspace projects
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              filter:
+                where:
+                  and:
+                    - name: AppConnect
+                    - workspace_id: '7878215'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: If2
+                    $ref: '#/block/For each/node-output/If 2/response/payload'
+                  - variable: FactorialHRRetrieveshifts
+                    $ref: >-
+                      #/node-output/Factorial HR Retrieve
+                      shifts/response/payload
+                  - variable: FactorialHRRetrieveshiftsMetadata
+                    $ref: '#/node-output/Factorial HR Retrieve shifts/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: false
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: false
+          - custom-action:
+              name: Toggl Track Create time entry
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              action: postWorkspacesByWorkspaceIdTimeEntries
+              map:
+                mappings:
+                  - created_with:
+                      template: '{{$Foreachitem.employee_id}}'
+                  - project_id:
+                      expression: '$TogglTrackRetrieveworkspaceprojects.id '
+                  - start:
+                      template: >-
+                        {{$Foreachitem._year_}}-{{$If.NewMonth}}-{{$If2.NewDate}}T{{$Foreachitem.clock_in}}:00Z
+                  - stop:
+                      template: >-
+                        {{$Foreachitem._year_}}-{{$If.NewMonth}}-{{$If2.NewDate}}T{{$Foreachitem.clock_out}}:00Z
+                  - workspace_id:
+                      template: '7878215'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: If2
+                    $ref: '#/block/For each/node-output/If 2/response/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: Seamless sync time entries between Factorial HR and Toggl Track
+models: {}


### PR DESCRIPTION
This PR covers the yaml files for usecases of FactorialHR:

usecase1:Seamless sync time entries between Factorial HR and Toggl Track

usecase2:Create event in Google Calendar for applied leave in Factorial HR
