### PR TITLE
usecase for zohobooks

### DIFF
--- a/resources/Creating zoho books expenses for square payments.yaml
+++ b/resources/Creating zoho books expenses for square payments.yaml
@@ -27,7 +27,6 @@ integration:
                     - SUN
                   timeZone: UTC
       connector-type: streaming-connector-scheduler
-      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Creating zoho books expenses for square payments.yaml
+++ b/resources/Creating zoho books expenses for square payments.yaml
@@ -1,0 +1,177 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: false
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      connector-type: streaming-connector-scheduler
+      account-name: Account 2
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: payments
+      connector-type: square
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: getExpenses_model
+      connector-type: zohobooks
+      actions:
+        RETRIEVEALL: {}
+    action-interface-3:
+      type: api-action
+      business-object: postExpense_model
+      connector-type: zohobooks
+      actions:
+        postExpense: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Square Retrieve payments
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  and:
+                    - begin_time: '{{$split($Trigger.lastEventTime , "+")[0]}}'
+                    - location_id: LS78PYWXTAFK2
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 100
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$SquareRetrievepayments '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              display-name: Square payments
+          - logging:
+              name: Log
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings:
+                  - logLevel:
+                      template: Info
+                  - logMessage:
+                      template: Expenses are created
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreach
+                    $ref: '#/node-output/For each/response/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+        tags:
+          - incomplete
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Zoho Books List expenses
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              filter:
+                where:
+                  reference_number: '{{$Foreachitem.id}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: SquareRetrievepayments
+                    $ref: '#/node-output/Square Retrieve payments/response/payload'
+                  - variable: SquareRetrievepaymentsMetadata
+                    $ref: '#/node-output/Square Retrieve payments/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - if:
+              name: If
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$ZohoBooksListexpensesMetadata."status-code"}}': '204'
+                  execute:
+                    - custom-action:
+                        name: Zoho Books Create expense
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-3'
+                        action: postExpense
+                        map:
+                          mappings:
+                            - account_id:
+                                template: '1332619000000000570'
+                            - amount:
+                                expression: '$Foreachitem.amount_money.amount '
+                            - date:
+                                template: '{{$split($Foreachitem.updated_at , "T")[0]}}'
+                            - description:
+                                template: >-
+                                  {{$Foreachitem.statement_description_identifier}}
+                            - paid_through_account_id:
+                                template: '1332619000000015012'
+                            - reference_number:
+                                template: '{{$Foreachitem.id}}'
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+              else:
+                execute: []
+              output-schema: {}
+  name: Creating zoho books expenses for square payments
+models: {}

--- a/resources/Creating zoho books invoices for shopify orders and sending an email using gmail.yaml
+++ b/resources/Creating zoho books invoices for shopify orders and sending an email using gmail.yaml
@@ -27,7 +27,6 @@ integration:
                     - SAT
                     - SUN
                   timeZone: UTC
-      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Creating zoho books invoices for shopify orders and sending an email using gmail.yaml
+++ b/resources/Creating zoho books invoices for shopify orders and sending an email using gmail.yaml
@@ -1,0 +1,803 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: false
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      account-name: Account 2
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: order
+      connector-type: shopify
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postInvoices_model
+      connector-type: zohobooks
+      actions:
+        postInvoices: {}
+    action-interface-3:
+      type: api-action
+      business-object: mail
+      connector-type: gmail
+      actions:
+        CREATE: {}
+    action-interface-4:
+      type: api-action
+      business-object: customer
+      connector-type: shopify
+      actions:
+        RETRIEVEALL: {}
+    action-interface-5:
+      type: api-action
+      business-object: postCustomers_model
+      connector-type: zohobooks
+      actions:
+        postCustomers: {}
+    action-interface-6:
+      type: api-action
+      business-object: getCustomers_model
+      connector-type: zohobooks
+      actions:
+        RETRIEVEALL: {}
+    action-interface-7:
+      type: api-action
+      business-object: postCustomers_model
+      connector-type: zohobooks
+      actions:
+        postCustomers: {}
+    action-interface-8:
+      type: api-action
+      business-object: getItems_model
+      connector-type: zohobooks
+      actions:
+        RETRIEVEALL: {}
+    action-interface-9:
+      type: api-action
+      business-object: postItems_model
+      connector-type: zohobooks
+      actions:
+        postItems: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Shopify Retrieve orders
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  created_at_min: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ShopifyRetrieveorders '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                customSchemas:
+                  properties.`output`:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      Cusotmer_ID:
+                        type: string
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrievecustomers
+                    $ref: >-
+                      #/block/For each/node-output/Shopify Retrieve
+                      customers/response/payload
+                  - variable: ShopifyRetrievecustomersMetadata
+                    $ref: >-
+                      #/block/For each/node-output/Shopify Retrieve
+                      customers/response
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: ZohoBooksCreateinvoice
+                    $ref: >-
+                      #/block/For each/node-output/Zoho Books Create
+                      invoice/response/payload
+                  - variable: GmailSendemail
+                    $ref: >-
+                      #/block/For each/node-output/Gmail Send
+                      email/response/payload
+                  - variable: ShopifyRetrieveorders
+                    $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                  - variable: ShopifyRetrieveordersMetadata
+                    $ref: '#/node-output/Shopify Retrieve orders/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                mappings:
+                  - output:
+                      mappings:
+                        - Cusotmer_ID:
+                            template: '{{$If.Customer_ID}}'
+                        - id:
+                            template: ' {{$ZohoBooksCreateinvoice.invoice_number}}'
+              display-name: Shopify order
+          - logging:
+              name: Log
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings:
+                  - logLevel:
+                      template: Info
+                  - logMessage:
+                      template: Order Number=>{{$Foreach.output.Order_Number}}
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreach
+                    $ref: '#/node-output/For each/response/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+        tags:
+          - incomplete
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Shopify Retrieve customers
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-4'
+              filter:
+                where:
+                  id: '{{$Foreachitem.customer.id}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrieveorders
+                    $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                  - variable: ShopifyRetrieveordersMetadata
+                    $ref: '#/node-output/Shopify Retrieve orders/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: false
+          - if:
+              name: If
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$ShopifyRetrievecustomers.email}}':
+                      '=': ''
+                  execute:
+                    - custom-action:
+                        name: Zoho Books Create customer
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-5'
+                        action: postCustomers
+                        map:
+                          mappings:
+                            - contact_name:
+                                template: '{{$ShopifyRetrievecustomers.first_name}}'
+                            - contact_persons:
+                                foreach:
+                                  input: '[{}]'
+                                  iterator: contact_personsItem
+                                  mappings:
+                                    - first_name:
+                                        template: '{{$ShopifyRetrievecustomers.first_name}}'
+                                    - last_name:
+                                        template: '{{$ShopifyRetrievecustomers.last_name}}'
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                  map:
+                    mappings:
+                      - Customer_ID:
+                          template: '{{$ZohoBooksCreatecustomer.contact_id}}'
+                    $map: http://ibm.com/appconnect/map/v1
+                    input:
+                      - variable: Foreachitem
+                        $ref: '#/block/For each/current-item'
+                      - variable: Trigger
+                        $ref: '#/trigger/payload'
+                      - variable: ZohoBooksCreatecustomer
+                        $ref: >-
+                          #/block/If/node-output/Zoho Books Create
+                          customer/response/payload
+                      - variable: ShopifyRetrievecustomers
+                        $ref: >-
+                          #/block/For each/node-output/Shopify Retrieve
+                          customers/response/payload
+                      - variable: ShopifyRetrievecustomersMetadata
+                        $ref: >-
+                          #/block/For each/node-output/Shopify Retrieve
+                          customers/response
+                      - variable: ShopifyRetrieveorders
+                        $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                      - variable: ShopifyRetrieveordersMetadata
+                        $ref: '#/node-output/Shopify Retrieve orders/response'
+                      - variable: flowDetails
+                        $ref: '#/flowDetails'
+              else:
+                execute:
+                  - retrieve-action:
+                      name: Zoho Books Retrieve customers
+                      target:
+                        $ref: '#/integration/action-interfaces/action-interface-6'
+                      filter:
+                        where:
+                          email: '{{$ShopifyRetrievecustomers.email}}'
+                        input:
+                          - variable: Foreachitem
+                            $ref: '#/block/For each/current-item'
+                          - variable: Trigger
+                            $ref: '#/trigger/payload'
+                          - variable: ShopifyRetrievecustomers
+                            $ref: >-
+                              #/block/For each/node-output/Shopify Retrieve
+                              customers/response/payload
+                          - variable: ShopifyRetrievecustomersMetadata
+                            $ref: >-
+                              #/block/For each/node-output/Shopify Retrieve
+                              customers/response
+                          - variable: ShopifyRetrieveorders
+                            $ref: >-
+                              #/node-output/Shopify Retrieve
+                              orders/response/payload
+                          - variable: ShopifyRetrieveordersMetadata
+                            $ref: '#/node-output/Shopify Retrieve orders/response'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        limit: 10
+                      allow-truncation: false
+                      pagination-type: SKIP_LIMIT
+                      allow-empty-output: true
+                  - if:
+                      name: If 2
+                      input:
+                        - variable: Trigger
+                          $ref: '#/trigger/payload'
+                        - variable: Foreachitem
+                          $ref: '#/block/For each/current-item'
+                        - variable: flowDetails
+                          $ref: '#/flowDetails'
+                      branch:
+                        - condition:
+                            '{{$ZohoBooksRetrievecustomersMetadata."status-code"}}': '204'
+                          execute:
+                            - custom-action:
+                                name: Zoho Books Create customer 2
+                                target:
+                                  $ref: >-
+                                    #/integration/action-interfaces/action-interface-7
+                                action: postCustomers
+                                map:
+                                  mappings:
+                                    - contact_name:
+                                        template: '{{$ShopifyRetrievecustomers.first_name}}'
+                                    - contact_persons:
+                                        foreach:
+                                          input: '[{}]'
+                                          iterator: contact_personsItem
+                                          mappings:
+                                            - email:
+                                                template: '{{$ShopifyRetrievecustomers.email}}'
+                                            - first_name:
+                                                template: '{{$ShopifyRetrievecustomers.first_name}}'
+                                            - last_name:
+                                                template: '{{$ShopifyRetrievecustomers.last_name}}'
+                                  $map: http://ibm.com/appconnect/map/v1
+                                  input:
+                                    - variable: Trigger
+                                      $ref: '#/trigger/payload'
+                                    - variable: Foreachitem
+                                      $ref: '#/block/For each/current-item'
+                                    - variable: flowDetails
+                                      $ref: '#/flowDetails'
+                          map:
+                            $map: http://ibm.com/appconnect/map/v1
+                            input:
+                              - variable: Foreachitem
+                                $ref: '#/block/For each/current-item'
+                              - variable: Trigger
+                                $ref: '#/trigger/payload'
+                              - variable: ZohoBooksCreatecustomer2
+                                $ref: >-
+                                  #/block/If 2/node-output/Zoho Books Create
+                                  customer 2/response/payload
+                              - variable: ZohoBooksRetrievecustomers
+                                $ref: >-
+                                  #/block/If/node-output/Zoho Books Retrieve
+                                  customers/response/payload
+                              - variable: ZohoBooksRetrievecustomersMetadata
+                                $ref: >-
+                                  #/block/If/node-output/Zoho Books Retrieve
+                                  customers/response
+                              - variable: ShopifyRetrievecustomers
+                                $ref: >-
+                                  #/block/For each/node-output/Shopify Retrieve
+                                  customers/response/payload
+                              - variable: ShopifyRetrievecustomersMetadata
+                                $ref: >-
+                                  #/block/For each/node-output/Shopify Retrieve
+                                  customers/response
+                              - variable: ShopifyRetrieveorders
+                                $ref: >-
+                                  #/node-output/Shopify Retrieve
+                                  orders/response/payload
+                              - variable: ShopifyRetrieveordersMetadata
+                                $ref: '#/node-output/Shopify Retrieve orders/response'
+                              - variable: flowDetails
+                                $ref: '#/flowDetails'
+                            mappings:
+                              - Customer_ID:
+                                  template: '{{$ZohoBooksCreatecustomer2.contact_id}}'
+                      else:
+                        execute: []
+                        map:
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: ZohoBooksRetrievecustomers
+                              $ref: >-
+                                #/block/If/node-output/Zoho Books Retrieve
+                                customers/response/payload
+                            - variable: ZohoBooksRetrievecustomersMetadata
+                              $ref: >-
+                                #/block/If/node-output/Zoho Books Retrieve
+                                customers/response
+                            - variable: ShopifyRetrievecustomers
+                              $ref: >-
+                                #/block/For each/node-output/Shopify Retrieve
+                                customers/response/payload
+                            - variable: ShopifyRetrievecustomersMetadata
+                              $ref: >-
+                                #/block/For each/node-output/Shopify Retrieve
+                                customers/response
+                            - variable: ShopifyRetrieveorders
+                              $ref: >-
+                                #/node-output/Shopify Retrieve
+                                orders/response/payload
+                            - variable: ShopifyRetrieveordersMetadata
+                              $ref: '#/node-output/Shopify Retrieve orders/response'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                          mappings:
+                            - Customer_ID:
+                                template: '{{$ZohoBooksRetrievecustomers.contact_id}}'
+                      output-schema:
+                        type: object
+                        properties:
+                          Customer_ID:
+                            type: string
+                        required: []
+                map:
+                  mappings:
+                    - Customer_ID:
+                        template: '{{$If2.Customer_ID}}'
+                  $map: http://ibm.com/appconnect/map/v1
+                  input:
+                    - variable: Foreachitem
+                      $ref: '#/block/For each/current-item'
+                    - variable: Trigger
+                      $ref: '#/trigger/payload'
+                    - variable: ZohoBooksRetrievecustomers
+                      $ref: >-
+                        #/block/If/node-output/Zoho Books Retrieve
+                        customers/response/payload
+                    - variable: ZohoBooksRetrievecustomersMetadata
+                      $ref: >-
+                        #/block/If/node-output/Zoho Books Retrieve
+                        customers/response
+                    - variable: If2
+                      $ref: '#/block/If/node-output/If 2/response/payload'
+                    - variable: ShopifyRetrievecustomers
+                      $ref: >-
+                        #/block/For each/node-output/Shopify Retrieve
+                        customers/response/payload
+                    - variable: ShopifyRetrievecustomersMetadata
+                      $ref: >-
+                        #/block/For each/node-output/Shopify Retrieve
+                        customers/response
+                    - variable: ShopifyRetrieveorders
+                      $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                    - variable: ShopifyRetrieveordersMetadata
+                      $ref: '#/node-output/Shopify Retrieve orders/response'
+                    - variable: flowDetails
+                      $ref: '#/flowDetails'
+              output-schema:
+                type: object
+                properties:
+                  Customer_ID:
+                    type: string
+                required: []
+          - for-each:
+              name: For each 2
+              assembly:
+                $ref: '#/integration/assemblies/assembly-3'
+              source:
+                expression: '$Foreachitem.line_items '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                customSchemas:
+                  properties.`output`:
+                    type: object
+                    properties:
+                      Line_Items:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            item_id:
+                              type: string
+                            quantity:
+                              type: number
+                            discount:
+                              type: number
+                input:
+                  - variable: Foreach2item
+                    $ref: '#/block/For each 2/current-item'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ZohoBooksRetrieveitems
+                    $ref: >-
+                      #/block/For each 2/node-output/Zoho Books Retrieve
+                      items/response/payload
+                  - variable: ZohoBooksRetrieveitemsMetadata
+                    $ref: >-
+                      #/block/For each 2/node-output/Zoho Books Retrieve
+                      items/response
+                  - variable: If3
+                    $ref: '#/block/For each 2/node-output/If 3/response/payload'
+                  - variable: ShopifyRetrievecustomers
+                    $ref: >-
+                      #/block/For each/node-output/Shopify Retrieve
+                      customers/response/payload
+                  - variable: ShopifyRetrievecustomersMetadata
+                    $ref: >-
+                      #/block/For each/node-output/Shopify Retrieve
+                      customers/response
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: ShopifyRetrieveorders
+                    $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                  - variable: ShopifyRetrieveordersMetadata
+                    $ref: '#/node-output/Shopify Retrieve orders/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                mappings:
+                  - output:
+                      mappings:
+                        - Line_Items:
+                            foreach:
+                              input: '[{}]'
+                              iterator: Line_ItemsItem
+                              mappings:
+                                - discount:
+                                    expression: '$If3.Line_Items.Discount '
+                                - item_id:
+                                    template: '{{$If3.Line_Items.item_id}}'
+                                - quantity:
+                                    expression: '$If3.Line_Items.quantity '
+              display-name: Shopify Line Items
+          - custom-action:
+              name: Zoho Books Create invoice
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              action: postInvoices
+              map:
+                mappings:
+                  - customer_id:
+                      template: '{{$If.Customer_ID}}'
+                  - line_items:
+                      foreach:
+                        mappings:
+                          - discount:
+                              expression: '$line_itemsItem.discount '
+                          - item_id:
+                              template: '{{$line_itemsItem.item_id}}'
+                          - quantity:
+                              expression: '$line_itemsItem.quantity '
+                        input: '$Foreach2.output.Line_Items '
+                        iterator: line_itemsItem
+                  - reference_number:
+                      template: '{{$Foreachitem.id}}'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: Foreach2
+                    $ref: '#/block/For each/node-output/For each 2/response/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+          - create-action:
+              name: Gmail Send email
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              map:
+                mappings:
+                  - Body:
+                      template: '{{$ZohoBooksCreateinvoice.invoice_id}}'
+                  - To:
+                      template: venkatkona790@gmail.com
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: Foreach2
+                    $ref: '#/block/For each/node-output/For each 2/response/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+    assembly-3:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Zoho Books Retrieve items
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-8'
+              filter:
+                where:
+                  name: '{{$Foreach2item.title}}'
+                input:
+                  - variable: Foreach2item
+                    $ref: '#/block/For each 2/current-item'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrievecustomers
+                    $ref: >-
+                      #/block/For each/node-output/Shopify Retrieve
+                      customers/response/payload
+                  - variable: ShopifyRetrievecustomersMetadata
+                    $ref: >-
+                      #/block/For each/node-output/Shopify Retrieve
+                      customers/response
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: ShopifyRetrieveorders
+                    $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                  - variable: ShopifyRetrieveordersMetadata
+                    $ref: '#/node-output/Shopify Retrieve orders/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: false
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - if:
+              name: If 3
+              input:
+                - variable: Trigger
+                  $ref: '#/trigger/payload'
+                - variable: If
+                  $ref: '#/block/For each/node-output/If/response/payload'
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Foreach2item
+                  $ref: '#/block/For each 2/current-item'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$ZohoBooksRetrieveitemsMetadata."status-code"}}': '204'
+                  execute:
+                    - custom-action:
+                        name: Zoho Books Create item
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-9'
+                        action: postItems
+                        map:
+                          mappings:
+                            - name:
+                                template: '{{$Foreach2item.title}}'
+                            - rate:
+                                expression: '$Foreach2item.price '
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Trigger
+                              $ref: '#/trigger/payload'
+                            - variable: If
+                              $ref: '#/block/For each/node-output/If/response/payload'
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Foreach2item
+                              $ref: '#/block/For each 2/current-item'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                  map:
+                    mappings:
+                      - Line_Items:
+                          foreach:
+                            input: '[{}]'
+                            iterator: Line_ItemsItem
+                            mappings:
+                              - Discount:
+                                  expression: '$Foreach2item.total_discount '
+                              - item_id:
+                                  template: '{{$ZohoBooksCreateitem.item_id}}'
+                              - quantity:
+                                  expression: '$Foreach2item.quantity '
+                    $map: http://ibm.com/appconnect/map/v1
+                    input:
+                      - variable: Foreach2item
+                        $ref: '#/block/For each 2/current-item'
+                      - variable: Foreachitem
+                        $ref: '#/block/For each/current-item'
+                      - variable: Trigger
+                        $ref: '#/trigger/payload'
+                      - variable: ZohoBooksCreateitem
+                        $ref: >-
+                          #/block/If 3/node-output/Zoho Books Create
+                          item/response/payload
+                      - variable: ZohoBooksRetrieveitems
+                        $ref: >-
+                          #/block/For each 2/node-output/Zoho Books Retrieve
+                          items/response/payload
+                      - variable: ZohoBooksRetrieveitemsMetadata
+                        $ref: >-
+                          #/block/For each 2/node-output/Zoho Books Retrieve
+                          items/response
+                      - variable: ShopifyRetrievecustomers
+                        $ref: >-
+                          #/block/For each/node-output/Shopify Retrieve
+                          customers/response/payload
+                      - variable: ShopifyRetrievecustomersMetadata
+                        $ref: >-
+                          #/block/For each/node-output/Shopify Retrieve
+                          customers/response
+                      - variable: If
+                        $ref: '#/block/For each/node-output/If/response/payload'
+                      - variable: ShopifyRetrieveorders
+                        $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                      - variable: ShopifyRetrieveordersMetadata
+                        $ref: '#/node-output/Shopify Retrieve orders/response'
+                      - variable: flowDetails
+                        $ref: '#/flowDetails'
+              else:
+                execute: []
+                map:
+                  mappings:
+                    - Line_Items:
+                        foreach:
+                          input: '[{}]'
+                          iterator: Line_ItemsItem
+                          mappings:
+                            - Discount:
+                                expression: '$Foreach2item.total_discount '
+                            - item_id:
+                                template: '{{$ZohoBooksRetrieveitems.item_id}}'
+                            - quantity:
+                                expression: '$Foreach2item.quantity '
+                  $map: http://ibm.com/appconnect/map/v1
+                  input:
+                    - variable: Foreach2item
+                      $ref: '#/block/For each 2/current-item'
+                    - variable: Foreachitem
+                      $ref: '#/block/For each/current-item'
+                    - variable: Trigger
+                      $ref: '#/trigger/payload'
+                    - variable: ZohoBooksRetrieveitems
+                      $ref: >-
+                        #/block/For each 2/node-output/Zoho Books Retrieve
+                        items/response/payload
+                    - variable: ZohoBooksRetrieveitemsMetadata
+                      $ref: >-
+                        #/block/For each 2/node-output/Zoho Books Retrieve
+                        items/response
+                    - variable: ShopifyRetrievecustomers
+                      $ref: >-
+                        #/block/For each/node-output/Shopify Retrieve
+                        customers/response/payload
+                    - variable: ShopifyRetrievecustomersMetadata
+                      $ref: >-
+                        #/block/For each/node-output/Shopify Retrieve
+                        customers/response
+                    - variable: If
+                      $ref: '#/block/For each/node-output/If/response/payload'
+                    - variable: ShopifyRetrieveorders
+                      $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                    - variable: ShopifyRetrieveordersMetadata
+                      $ref: '#/node-output/Shopify Retrieve orders/response'
+                    - variable: flowDetails
+                      $ref: '#/flowDetails'
+              output-schema:
+                type: object
+                properties:
+                  Line_Items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        item_id:
+                          type: string
+                        quantity:
+                          type: number
+                        Discount:
+                          type: number
+                      required: []
+                required: []
+  name: >-
+    Creating zoho books invoices for shopify orders and sending an email using
+    gmail
+models: {}

--- a/resources/Creating zoho books items for shopify products.yaml
+++ b/resources/Creating zoho books items for shopify products.yaml
@@ -1,0 +1,303 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: api
+  trigger-interfaces:
+    trigger-interface-1:
+      triggers:
+        createItems:
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          input-context:
+            data: Items
+          output-context:
+            data: Items
+      options:
+        resources:
+          - business-object: Items
+            model:
+              $ref: '#/models/Items'
+            triggers:
+              create: createItems
+      type: api-trigger
+  action-interfaces:
+    action-interface-3:
+      type: api-action
+      business-object: product
+      connector-type: shopify
+      actions:
+        RETRIEVEALL: {}
+    action-interface-1:
+      type: api-action
+      business-object: postItems_model
+      connector-type: zohobooks
+      actions:
+        postItems: {}
+    action-interface-2:
+      type: api-action
+      business-object: getItems_model
+      connector-type: zohobooks
+      actions:
+        RETRIEVEALL: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Shopify Retrieve products
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              filter:
+                limit: 10
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: false
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ShopifyRetrieveproducts '
+                input:
+                  - variable: Request
+                    $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrieveproducts
+                    $ref: '#/node-output/Shopify Retrieve products/response/payload'
+                  - variable: ShopifyRetrieveproductsMetadata
+                    $ref: '#/node-output/Shopify Retrieve products/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                customSchemas:
+                  properties.`output`:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      Name:
+                        type: string
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Request
+                    $ref: '#/trigger/payload'
+                  - variable: ZohoBooksListitems
+                    $ref: >-
+                      #/block/For each/node-output/Zoho Books List
+                      items/response/payload
+                  - variable: ZohoBooksListitemsMetadata
+                    $ref: >-
+                      #/block/For each/node-output/Zoho Books List
+                      items/response
+                  - variable: If
+                    $ref: '#/block/For each/node-output/If/response/payload'
+                  - variable: ShopifyRetrieveproducts
+                    $ref: '#/node-output/Shopify Retrieve products/response/payload'
+                  - variable: ShopifyRetrieveproductsMetadata
+                    $ref: '#/node-output/Shopify Retrieve products/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                mappings:
+                  - output:
+                      mappings:
+                        - Name:
+                            template: '{{$If.Name}}'
+                        - id:
+                            template: '{{$If.id}}'
+              display-name: Shopify product
+          - response:
+              name: response-1
+              reply-maps:
+                - title: Customer successfully created
+                  status-code: '201'
+                  map:
+                    $map: http://ibm.com/appconnect/map/v1
+                    input:
+                      - variable: Request
+                        $ref: '#/trigger/payload'
+                      - variable: ShopifyRetrieveproducts
+                        $ref: >-
+                          #/node-output/Shopify Retrieve
+                          products/response/payload
+                      - variable: ShopifyRetrieveproductsMetadata
+                        $ref: '#/node-output/Shopify Retrieve products/response'
+                      - variable: Foreach
+                        $ref: '#/node-output/For each/response/payload'
+                      - variable: flowDetails
+                        $ref: '#/flowDetails'
+                    mappings:
+                      - Result:
+                          template: >-
+                            Input=>{{$ShopifyRetrieveproducts.title}}    
+                            Output=>{{$Foreach.output.Name}}
+                  input:
+                    - variable: Request
+                      $ref: '#/trigger/payload'
+                    - variable: ShopifyRetrieveproducts
+                      $ref: '#/node-output/Shopify Retrieve products/response/payload'
+                    - variable: ShopifyRetrieveproductsMetadata
+                      $ref: '#/node-output/Shopify Retrieve products/response'
+                    - variable: Foreach
+                      $ref: '#/node-output/For each/response/payload'
+                    - variable: flowDetails
+                      $ref: '#/flowDetails'
+        catch:
+          - default:
+              - response:
+                  name: response-1
+                  reply-maps:
+                    - title: Bad request
+                      status-code: 400
+                      map:
+                        $map: http://ibm.com/appconnect/map/v1
+                        input:
+                          - variable: Request
+                            $ref: '#/trigger/payload'
+                          - variable: errorDetails
+                            $ref: '#/error'
+                          - variable: flowDetails
+                            $ref: '#/flowDetails'
+                        mappings:
+                          - message:
+                              template: '{{$errorDetails}}'
+                      input: []
+        tags:
+          - incomplete
+    assembly-2:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Zoho Books List items
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              filter:
+                where:
+                  name: '{{$Foreachitem.title}}'
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Request
+                    $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrieveproducts
+                    $ref: '#/node-output/Shopify Retrieve products/response/payload'
+                  - variable: ShopifyRetrieveproductsMetadata
+                    $ref: '#/node-output/Shopify Retrieve products/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: false
+              pagination-type: SKIP_LIMIT
+              allow-empty-output: true
+          - if:
+              name: If
+              input:
+                - variable: Foreachitem
+                  $ref: '#/block/For each/current-item'
+                - variable: Request
+                  $ref: '#/trigger/payload'
+                - variable: ZohoBooksListitems
+                  $ref: >-
+                    #/block/For each/node-output/Zoho Books List
+                    items/response/payload
+                - variable: ZohoBooksListitemsMetadata
+                  $ref: '#/block/For each/node-output/Zoho Books List items/response'
+                - variable: ShopifyRetrieveproducts
+                  $ref: '#/node-output/Shopify Retrieve products/response/payload'
+                - variable: ShopifyRetrieveproductsMetadata
+                  $ref: '#/node-output/Shopify Retrieve products/response'
+                - variable: flowDetails
+                  $ref: '#/flowDetails'
+              branch:
+                - condition:
+                    '{{$ZohoBooksListitemsMetadata."status-code"}}': '204'
+                  execute:
+                    - custom-action:
+                        name: Zoho Books Create item
+                        target:
+                          $ref: '#/integration/action-interfaces/action-interface-1'
+                        action: postItems
+                        map:
+                          mappings:
+                            - name:
+                                template: '{{$Foreachitem.title}}'
+                            - rate:
+                                expression: '$Foreachitem.variants[0].price '
+                          $map: http://ibm.com/appconnect/map/v1
+                          input:
+                            - variable: Foreachitem
+                              $ref: '#/block/For each/current-item'
+                            - variable: Request
+                              $ref: '#/trigger/payload'
+                            - variable: ZohoBooksListitems
+                              $ref: >-
+                                #/block/For each/node-output/Zoho Books List
+                                items/response/payload
+                            - variable: ZohoBooksListitemsMetadata
+                              $ref: >-
+                                #/block/For each/node-output/Zoho Books List
+                                items/response
+                            - variable: ShopifyRetrieveproducts
+                              $ref: >-
+                                #/node-output/Shopify Retrieve
+                                products/response/payload
+                            - variable: ShopifyRetrieveproductsMetadata
+                              $ref: '#/node-output/Shopify Retrieve products/response'
+                            - variable: flowDetails
+                              $ref: '#/flowDetails'
+                  map:
+                    $map: http://ibm.com/appconnect/map/v1
+                    input:
+                      - variable: Foreachitem
+                        $ref: '#/block/For each/current-item'
+                      - variable: Request
+                        $ref: '#/trigger/payload'
+                      - variable: ZohoBooksCreateitem
+                        $ref: >-
+                          #/block/If/node-output/Zoho Books Create
+                          item/response/payload
+                      - variable: ZohoBooksListitems
+                        $ref: >-
+                          #/block/For each/node-output/Zoho Books List
+                          items/response/payload
+                      - variable: ZohoBooksListitemsMetadata
+                        $ref: >-
+                          #/block/For each/node-output/Zoho Books List
+                          items/response
+                      - variable: ShopifyRetrieveproducts
+                        $ref: >-
+                          #/node-output/Shopify Retrieve
+                          products/response/payload
+                      - variable: ShopifyRetrieveproductsMetadata
+                        $ref: '#/node-output/Shopify Retrieve products/response'
+                      - variable: flowDetails
+                        $ref: '#/flowDetails'
+                    mappings:
+                      - Name:
+                          template: '{{$ZohoBooksCreateitem.name}}'
+                      - id:
+                          template: '{{$ZohoBooksCreateitem.item_id}}'
+              else:
+                execute: []
+              output-schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  Name:
+                    type: string
+                required: []
+  name: Creating zoho books items for shopify products
+models:
+  Items:
+    name: Items
+    properties:
+      Result:
+        required: false
+        id: true
+        type: string
+    plural: Items
+    description: ' '
+    operations:
+      create: '#/integration/assemblies/assembly-1'

--- a/resources/Creating zoho books quotes for shopify orders and sending an slack message to the user.yaml
+++ b/resources/Creating zoho books quotes for shopify orders and sending an slack message to the user.yaml
@@ -27,7 +27,6 @@ integration:
                     - SAT
                     - SUN
                   timeZone: UTC
-      account-name: Account 2
   action-interfaces:
     action-interface-1:
       type: api-action

--- a/resources/Creating zoho books quotes for shopify orders and sending an slack message to the user.yaml
+++ b/resources/Creating zoho books quotes for shopify orders and sending an slack message to the user.yaml
@@ -1,0 +1,194 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      connector-type: streaming-connector-scheduler
+      type: event-trigger
+      triggers:
+        SCHEDULE:
+          input-context:
+            data: scheduler
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: false
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+      account-name: Account 2
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: order
+      connector-type: shopify
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postQuotes_model
+      connector-type: zohobooks
+      actions:
+        postQuotes: {}
+    action-interface-3:
+      type: api-action
+      business-object: message
+      connector-type: slack
+      actions:
+        CREATE: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              name: Shopify Retrieve orders
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                where:
+                  created_at_min: '{{$Trigger.lastEventTime}}'
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                limit: 10
+              allow-truncation: true
+              pagination-type: TOKEN
+              allow-empty-output: true
+          - for-each:
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              source:
+                expression: '$ShopifyRetrieveorders '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                customSchemas:
+                  properties.`output`:
+                    type: object
+                    properties:
+                      Order_Number:
+                        type: string
+                      id:
+                        type: string
+                input:
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ZohoBooksCreatequote
+                    $ref: >-
+                      #/block/For each/node-output/Zoho Books Create
+                      quote/response/payload
+                  - variable: ShopifyRetrieveorders
+                    $ref: '#/node-output/Shopify Retrieve orders/response/payload'
+                  - variable: ShopifyRetrieveordersMetadata
+                    $ref: '#/node-output/Shopify Retrieve orders/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+                mappings:
+                  - output:
+                      mappings:
+                        - Order_Number:
+                            template: '{{$ZohoBooksCreatequote.reference_number}}'
+                        - id:
+                            template: '{{$ZohoBooksCreatequote.estimate_id}}'
+              display-name: Shopify order
+          - logging:
+              name: Log
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings:
+                  - logLevel:
+                      template: Info
+                  - logMessage:
+                      template: Order Number=>{{$Foreach.output.Order_Number}}
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreach
+                    $ref: '#/node-output/For each/response/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+        tags:
+          - incomplete
+    assembly-2:
+      assembly:
+        execute:
+          - custom-action:
+              name: Zoho Books Create quote
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              action: postQuotes
+              map:
+                mappings:
+                  - customer_id:
+                      template: '1332619000000031077'
+                  - line_items:
+                      foreach:
+                        input: '$Foreachitem.line_items '
+                        iterator: line_itemsItem
+                        mappings:
+                          - description:
+                              template: '{{$line_itemsItem.title}}'
+                          - discount_amount:
+                              expression: '$line_itemsItem.total_discount '
+                          - item_id:
+                              template: '1332619000000289019'
+                          - quantity:
+                              expression: '$line_itemsItem.quantity '
+                          - rate:
+                              expression: '$line_itemsItem.price '
+                  - reference_number:
+                      template: '{{$Foreachitem.id}}'
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+          - create-action:
+              name: Slack Send message
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-3'
+              map:
+                mappings:
+                  - OBJECT_ID:
+                      template: D05FP3M0YGH
+                  - OBJECT_NAME:
+                      template: im
+                  - text:
+                      template: Quote is ready
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: >-
+    Creating zoho books quotes for shopify orders and sending an slack message
+    to the user
+models: {}

--- a/resources/markdown/Creating zoho books expenses for square payments.md
+++ b/resources/markdown/Creating zoho books expenses for square payments.md
@@ -1,0 +1,10 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Creating%20zoho%20books%20expenses%20for%20square%20payments_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [Square](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-square)
+   - [Zoho Books](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-zoho-books)
+   
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to create zoho books expenses for square payments

--- a/resources/markdown/Creating zoho books invoices for shopify orders and sending an email using gmail.md
+++ b/resources/markdown/Creating zoho books invoices for shopify orders and sending an email using gmail.md
@@ -1,0 +1,11 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Creating%20zoho%20books%20invoices%20for%20shopify%20orders%20and%20sending%20an%20email%20using%20gmail_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [Shopify](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-shopify)
+   - [Zoho Books](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-zoho-books)
+   - [Gmail](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-gmail)
+   
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to create zoho books invoices for shopify orders and sending an email using gmail

--- a/resources/markdown/Creating zoho books items for shopify products.md
+++ b/resources/markdown/Creating zoho books items for shopify products.md
@@ -1,0 +1,10 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Creating%20zoho%20books%20items%20for%20shopify%20products_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [Shopify](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-shopify)
+   - [Zoho Books](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-zoho-books)
+   
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to create zoho books items for shopify products

--- a/resources/markdown/Creating zoho books quotes for shopify orders and sending an slack message to the user.md
+++ b/resources/markdown/Creating zoho books quotes for shopify orders and sending an slack message to the user.md
@@ -1,0 +1,11 @@
+To refer to these instructions while editing the flow, open [the Github page](https://github.com/ot4i/app-connect-templates/blob/master/resources/markdown/Creating%20zoho%20books%20quotes%20for%20shopify%20orders%20and%20sending%20an%20slack%20message%20to%20the%20user_instructions.md) (opens in a new window).
+
+1. Click **Use this template** to start using the template.
+2. Connect to the following accounts by using your credentials:
+   - [Shopify](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-shopify)
+   - [Zoho Books](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-zoho-books)
+   - [Slack](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=apps-slack)
+   
+3. To start the flow, in the banner click **Start flow**.
+
+Use this template to create zoho books quotes for shopify orders and sending an slack message to the user

--- a/resources/template-metadata.json
+++ b/resources/template-metadata.json
@@ -3526,6 +3526,80 @@
     "targetApps": ["bamboohr", "apptiotargetprocess"],
     "tags": ["streaming-connector-scheduler", "bamboohr", "apptiotargetprocess"],
     "offerings": ["app connect professional"]
-  }  
+  },
+    {
+    "name": "Creating zoho books expenses for square payments",
+    "description": "Use this template to create zoho books expenses for square payments",
+    "summary": "Scheduler to 2 applications",
+    "sourceApp": "streaming-connector-scheduler",
+    "targetApps": [
+        "square",
+        "zohobooks"
+    ],
+    "tags": [
+        "streaming-connector-scheduler",
+        "square",
+        "zohobooks"
+    ],
+    "offerings": [
+        "app connect professional"
+    ]
+},
+{
+    "name": "Creating zoho books items for shopify products",
+    "description": "Use this template to create zoho books items for shopify products",
+    "summary": "1 flow using 2 applications",
+    "sourceApp": "shopify",
+    "targetApps": [
+        "zohobooks"
+    ],
+    "tags": [
+        "shopify",
+        "zohobooks"
+    ],
+    "offerings": [
+        "app connect professional"
+    ]
+},
+{
+    "name": "Creating zoho books invoices for shopify orders and sending an email using gmail",
+    "description": "Use this template to create zoho books invoices for shopify orders and sending an email using gmail",
+    "summary": "Scheduler to 3 applications",
+    "sourceApp": "streaming-connector-scheduler",
+    "targetApps": [
+        "shopify",
+        "zohobooks",
+        "gmail"
+    ],
+    "tags": [
+        "streaming-connector-scheduler",
+        "shopify",
+        "zohobooks",
+        "gmail"
+    ],
+    "offerings": [
+        "app connect professional"
+    ]
+},
+{
+    "name": "Creating zoho books quotes for shopify orders and sending an slack message to the user",
+    "description": "Use this template to create zoho books quotes for shopify orders and sending an slack message to the user",
+    "summary": "Scheduler to 3 applications",
+    "sourceApp": "streaming-connector-scheduler",
+    "targetApps": [
+        "shopify",
+        "zohobooks",
+        "slack"
+    ],
+    "tags": [
+        "streaming-connector-scheduler",
+        "shopify",
+        "zohobooks",
+        "slack"
+    ],
+    "offerings": [
+        "app connect professional"
+    ]
+}
 ]
 }


### PR DESCRIPTION
This PR contains yaml, md and metadata files for Zoho books usecases.
usecase1:Creating zoho books expenses for square payments
usecase2:Creating zoho books items for shopify products
usecase3:Creating zoho books invoices for shopify orders and sending an email using gmail
usecase4:Creating zoho books quotes for shopify orders and sending an slack message to the user