### PR TITLE
Added usecase for Crystal Ball

### DIFF
--- a/resources/Create an annotation in Crystal Ball for any new contact created in Salesforce.yaml
+++ b/resources/Create an annotation in Crystal Ball for any new contact created in Salesforce.yaml
@@ -1,0 +1,119 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      connector-type: streaming-connector-scheduler
+      triggers:
+        SCHEDULE:
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          input-context:
+            data: scheduler
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: false
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: Contact
+      connector-type: salesforce
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postApiV1Annotations_model
+      connector-type: crystalball
+      actions:
+        postApiV1Annotations: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              allow-empty-output: false
+              allow-truncation: true
+              name: Salesforce Retrieve contacts
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                limit: 10
+                where:
+                  CreatedDate: time
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              pagination-type: TOKEN
+          - for-each:
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              source:
+                expression: '$SalesforceRetrievecontacts '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: SalesforceRetrievecontacts
+                    $ref: >-
+                      #/node-output/Salesforce Retrieve
+                      contacts/response/payload
+                  - variable: SalesforceRetrievecontactsMetadata
+                    $ref: '#/node-output/Salesforce Retrieve contacts/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              display-name: Salesforce Contact
+    assembly-2:
+      assembly:
+        execute:
+          - custom-action:
+              action: postApiV1Annotations
+              name: Crystal Ball Create annotation
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              map:
+                mappings:
+                  - category:
+                      template: salesforce  {{$Foreachitem.Id}}
+                  - description:
+                      template: '{{$Foreachitem.Description}}'
+                  - event_name:
+                      template: contact_create {{$SalesforceRetrievecontacts.LastName}}
+                  - url:
+                      template: salesforce.com
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: SalesforceRetrievecontacts
+                    $ref: >-
+                      #/node-output/Salesforce Retrieve
+                      contacts/response/payload
+                  - variable: SalesforceRetrievecontactsMetadata
+                    $ref: '#/node-output/Salesforce Retrieve contacts/response'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: sftocb
+models: {}

--- a/resources/Create an annotation in Crystal Ball for any new product created in Shopify.yaml
+++ b/resources/Create an annotation in Crystal Ball for any new product created in Shopify.yaml
@@ -1,0 +1,117 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      connector-type: streaming-connector-scheduler
+      triggers:
+        SCHEDULE:
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          input-context:
+            data: scheduler
+          options:
+            subscription:
+              scheduleConfiguration:
+                interval:
+                  unit: minute
+                  value: 1
+                  runOnceOncheck: false
+                  days:
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - SUN
+                  timeZone: UTC
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: product
+      connector-type: shopify
+      actions:
+        RETRIEVEALL: {}
+    action-interface-2:
+      type: api-action
+      business-object: postApiV1Annotations_model
+      connector-type: crystalball
+      actions:
+        postApiV1Annotations: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - retrieve-action:
+              allow-empty-output: false
+              allow-truncation: true
+              name: Shopify Retrieve products
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              filter:
+                limit: 10
+                where:
+                  and:
+                    - created_at_min: '{{$Trigger.lastEventTime}}'
+                    - status: active
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              pagination-type: TOKEN
+          - for-each:
+              map:
+                $map: http://ibm.com/appconnect/map/v1
+                mappings: []
+              source:
+                expression: '$ShopifyRetrieveproducts '
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrieveproducts
+                    $ref: '#/node-output/Shopify Retrieve products/response/payload'
+                  - variable: ShopifyRetrieveproductsMetadata
+                    $ref: '#/node-output/Shopify Retrieve products/response'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+              mode: sequential
+              continue-on-error: true
+              name: For each
+              assembly:
+                $ref: '#/integration/assemblies/assembly-2'
+              display-name: Shopify product
+    assembly-2:
+      assembly:
+        execute:
+          - custom-action:
+              action: postApiV1Annotations
+              name: Crystal Ball Create annotation
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-2'
+              map:
+                mappings:
+                  - category:
+                      template: shopify {{$Foreachitem.id}}
+                  - description:
+                      template: '{{$Foreachitem.body_html}}'
+                  - event_name:
+                      template: product_create
+                  - url:
+                      template: shopify.com
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: ShopifyRetrieveproducts
+                    $ref: '#/node-output/Shopify Retrieve products/response/payload'
+                  - variable: ShopifyRetrieveproductsMetadata
+                    $ref: '#/node-output/Shopify Retrieve products/response'
+                  - variable: Foreachitem
+                    $ref: '#/block/For each/current-item'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: shopify
+models: {}

--- a/resources/Create an annotation in Crystal Ball for new Mailchimp campaigns.yaml
+++ b/resources/Create an annotation in Crystal Ball for new Mailchimp campaigns.yaml
@@ -1,0 +1,51 @@
+$integration: http://ibm.com/appconnect/integration/v2/integrationFile
+integration:
+  type: trigger-action
+  trigger-interfaces:
+    trigger-interface-1:
+      type: event-trigger
+      connector-type: mailchimp
+      triggers:
+        CREATED:
+          assembly:
+            $ref: '#/integration/assemblies/assembly-1'
+          input-context:
+            data: Campaigns
+          options:
+            list_id: 6fc8383307
+            parentFilter:
+              list_id: 6fc8383307
+  action-interfaces:
+    action-interface-1:
+      type: api-action
+      business-object: postApiV1Annotations_model
+      connector-type: crystalball
+      actions:
+        postApiV1Annotations: {}
+  assemblies:
+    assembly-1:
+      assembly:
+        execute:
+          - custom-action:
+              action: postApiV1Annotations
+              name: Crystal Ball Create annotation
+              target:
+                $ref: '#/integration/action-interfaces/action-interface-1'
+              map:
+                mappings:
+                  - category:
+                      template: '{{$Trigger.id}} created'
+                  - description:
+                      template: mailchimp
+                  - event_name:
+                      template: campaign
+                  - url:
+                      template: https://mailchimp.com/
+                $map: http://ibm.com/appconnect/map/v1
+                input:
+                  - variable: Trigger
+                    $ref: '#/trigger/payload'
+                  - variable: flowDetails
+                    $ref: '#/flowDetails'
+  name: mailchimp
+models: {}


### PR DESCRIPTION
This PR covers yaml for usecases for Crystal Ball:
Usecase1: For every new product created in Shopify, it creates an annotation in Crystal Ball.
Usecase2: Creates an annotation in Crystal Ball for any new Mailchimp campaign.
Usecase3: When a new contact is created in Salesforce, it adds an annotation in the account for an event in Crystal Ball.