### PR TITLE
Use case template for Azurecosmosdb

### DIFF
--- a/resources/Create a message in a new Google Pub Sub topic using data from Azure Cosmos DB when a new message is received.yaml
+++ b/resources/Create a message in a new Google Pub Sub topic using data from Azure Cosmos DB when a new message is received.yaml
@@ -73,7 +73,7 @@ integration:
                     - id: '{{$Trigger.attributes.orderId}}'
                     - partitionKey: '{{$Trigger.attributes.company}}'
                     - ContainerId: shipments
-                    - DatabaseId: DHL
+                    - DatabaseId: SampleID
                 input:
                   - variable: Trigger
                     $ref: '#/trigger/payload'
@@ -114,5 +114,5 @@ integration:
                       ID/response/payload
                   - variable: flowDetails
                     $ref: '#/flowDetails'
-  name: usecase
+  name: Create a message in a new Google Pub Sub topic using data from Azure Cosmos DB when a new message is received
 models: {}


### PR DESCRIPTION
Usecase template for Azure Cosmos DB
-Creating a new message in a new Google Cloud Pub/Sub topic using the details retrieved from Azure Cosmos DB item whenever a new message is received in a topic.